### PR TITLE
Adding ID field to Pin

### DIFF
--- a/XFGoogleMapSample/XFGoogleMapSample/BindingPinViewPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/BindingPinViewPage.xaml.cs
@@ -19,7 +19,8 @@ namespace XFGoogleMapSample
 
 			var pin = new Pin()
 			{
-				Type = PinType.Place,
+                //ID = "123", // optional, client app pin id for reference of this pin
+                Type = PinType.Place,
 				Label = "Tokyo SKYTREE",
 				Address = "Sumida-ku, Tokyo, Japan",
 				Position = new Position(35.71d, 139.81d),

--- a/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml.cs
@@ -38,6 +38,7 @@ namespace XFGoogleMapSample
         // The pin
         readonly Pin _pinTokyo = new Pin()
         {
+            //ID = "123", // optional, client app pin id for reference of this pin
             Type = PinType.Place,
             Label = "Tokyo SKYTREE",
             Address = "Sumida-ku, Tokyo, Japan",

--- a/XFGoogleMapSample/XFGoogleMapSample/PinsPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/PinsPage.xaml.cs
@@ -20,6 +20,7 @@ namespace XFGoogleMapSample
             {
                 pinTokyo = new Pin()
                 {
+                    //ID = "123", // optional, client app pin id for reference of this pin
                     Type = PinType.Place,
                     Label = "Tokyo SKYTREE",
                     Address = "Sumida-ku, Tokyo, Japan",
@@ -49,6 +50,7 @@ namespace XFGoogleMapSample
             {
                 pinNewYork = new Pin()
                 {
+                    //ID = "123", // optional, client app pin id for reference of this pin
                     Type = PinType.Place,
                     Label = "Central Park NYC",
                     Address = "New York City, NY 10022",

--- a/XFGoogleMapSample/XFGoogleMapSample/ShapesWithInitializePage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/ShapesWithInitializePage.xaml.cs
@@ -42,6 +42,7 @@ namespace XFGoogleMapSample
 
             var pinNewYork = new Pin()
             {
+                //ID = "123", // optional, client app pin id for reference of this pin
                 Type = PinType.Place,
                 Label = "Central Park NYC",
                 Address = "New York City, NY 10022",

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Pin.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Pin.cs
@@ -4,6 +4,8 @@ namespace Xamarin.Forms.GoogleMaps
 {
     public sealed class Pin : BindableObject
     {
+        public static readonly BindableProperty IDProperty = BindableProperty.Create("ID", typeof(string), typeof(Pin), default(string));
+
         public static readonly BindableProperty TypeProperty = BindableProperty.Create("Type", typeof(PinType), typeof(Pin), default(PinType));
 
         public static readonly BindableProperty PositionProperty = BindableProperty.Create("Position", typeof(Position), typeof(Pin), default(Position));
@@ -15,6 +17,12 @@ namespace Xamarin.Forms.GoogleMaps
         public static readonly BindableProperty IconProperty = BindableProperty.Create("Icon", typeof(BitmapDescriptor), typeof(Pin), default(BitmapDescriptor));
 
         public static readonly BindableProperty IsDraggableProperty = BindableProperty.Create("IsDraggable", typeof(bool), typeof(Pin), false);
+
+        public string ID
+        {
+            get { return (string)GetValue(IDProperty); }
+            set { SetValue(IDProperty, value); }
+        }
 
         public string Label
         {
@@ -74,6 +82,7 @@ namespace Xamarin.Forms.GoogleMaps
             unchecked
             {
                 int hashCode = Label?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (ID?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ Position.GetHashCode();
                 hashCode = (hashCode * 397) ^ (int)Type;
                 hashCode = (hashCode * 397) ^ (Address?.GetHashCode() ?? 0);
@@ -103,7 +112,7 @@ namespace Xamarin.Forms.GoogleMaps
 
         bool Equals(Pin other)
         {
-            return string.Equals(Label, other.Label) && Equals(Position, other.Position) && Type == other.Type && string.Equals(Address, other.Address);
+            return string.Equals(ID, other.ID) && string.Equals(Label, other.Label) && Equals(Position, other.Position) && Type == other.Type && string.Equals(Address, other.Address);
         }
     }
 }


### PR DESCRIPTION
Added a client trackable "ID" field to pin.  This way, pins can be given an ID when added to the map, and when clicked, the app knows which pin
to refer to.  This is similar (and critical) to other mapping APIs (but apparently Xamarin left it out.)