### PR TITLE
Fix set Pin.Rotation does not work

### DIFF
--- a/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage
 	xmlns="http://xamarin.com/schemas/2014/forms"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -10,8 +10,9 @@
 			VerticalOptions="Fill"
 			Orientation="Vertical">
 
-			<Grid>
+			<Grid Margin="15,10,15,0">
 				<Grid.RowDefinitions>
+			        <RowDefinition Height="Auto" />
 			        <RowDefinition Height="Auto" />
 			        <RowDefinition Height="Auto" />
 			        <RowDefinition Height="Auto" />
@@ -89,9 +90,21 @@
 						HorizontalTextAlignment="Start"/>
 				</StackLayout>
 
+				<Label  Text="Rotation:"
+						HorizontalOptions="End"
+						VerticalOptions="Center"
+						Grid.Row="5" 
+						Grid.Column="0"
+						Grid.ColumnSpan="2"/>
+				<Slider x:Name="sliderRotation"
+						Minimum="0" 
+						Maximum="360"
+						Grid.Row="5" 
+						Grid.Column="2" />
+
 				<Label  x:Name="labelDragStatus"
 						Text="Show status when Pin drag."
-						Grid.Row="4"
+						Grid.Row="6"
 						Grid.Column="0"
 						Grid.ColumnSpan="3"/>
 

--- a/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/CustomPinsPage.xaml.cs
@@ -122,6 +122,12 @@ namespace XFGoogleMapSample
                 _pinTokyo.IsDraggable = switchIsDraggable.IsToggled;
             };
 
+            // Pin Rotation
+            sliderRotation.ValueChanged += (sender, e) =>
+            {
+                _pinTokyo.Rotation = (float)e.NewValue;
+            };
+
             map.PinDragStart += (_, e) => labelDragStatus.Text = $"DragStart - {PrintPin(e.Pin)}";
             map.PinDragging += (_, e) => labelDragStatus.Text = $"Dragging - {PrintPin(e.Pin)}";
             map.PinDragEnd += (_, e) => labelDragStatus.Text = $"DragEnd - {PrintPin(e.Pin)}";

--- a/XFGoogleMapSample/XFGoogleMapSample/PinsPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/PinsPage.xaml.cs
@@ -24,7 +24,7 @@ namespace XFGoogleMapSample
                     Label = "Tokyo SKYTREE",
                     Address = "Sumida-ku, Tokyo, Japan",
                     Position = new Position(35.71d, 139.81d),
-                    Rotation = 92.3
+                    Rotation = 92.3f
                 };
 
                 map.Pins.Add(pinTokyo);

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PinLogic.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.GoogleMaps.Android;
 using Xamarin.Forms.GoogleMaps.Android.Extensions;
 using NativeBitmapDescriptorFactory = Android.Gms.Maps.Model.BitmapDescriptorFactory;
 using Android.Widget;
+using System;
 
 namespace Xamarin.Forms.GoogleMaps.Logics.Android
 {
@@ -274,6 +275,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
         protected override void OnUpdateIsDraggable(Pin outerItem, Marker nativeItem)
         {
             nativeItem.Draggable = outerItem?.IsDraggable ?? false;
+        }
+
+        protected override void OnUpdateRotation(Pin outerItem, Marker nativeItem)
+        {
+            nativeItem.Rotation = outerItem?.Rotation ?? 0f;
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PinLogic.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -251,6 +252,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
                 });
             }
         }
-   }
+
+        protected override void OnUpdateRotation(Pin outerItem, Marker nativeItem)
+        {
+            nativeItem.Rotation = outerItem?.Rotation ?? 0f;
+        }
+    }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultPinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultPinLogic.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.GoogleMaps
             else if (e.PropertyName == Pin.TypeProperty.PropertyName) OnUpdateType(outerItem, nativeItem);
             else if (e.PropertyName == Pin.IconProperty.PropertyName) OnUpdateIcon(outerItem, nativeItem);
             else if (e.PropertyName == Pin.IsDraggableProperty.PropertyName) OnUpdateIsDraggable(outerItem, nativeItem);
+            else if (e.PropertyName == Pin.RotationProperty.PropertyName) OnUpdateRotation(outerItem, nativeItem);
         }
 
         protected abstract void OnUpdateAddress(Pin outerItem, TNative nativeItem);
@@ -35,6 +36,8 @@ namespace Xamarin.Forms.GoogleMaps
         protected abstract void OnUpdateIcon(Pin outerItem, TNative nativeItem);
 
         protected abstract void OnUpdateIsDraggable(Pin outerItem, TNative nativeItem);
+
+        protected abstract void OnUpdateRotation(Pin outerItem, TNative nativeItem);
     }
 }
 


### PR DESCRIPTION
## Set Pin.Rotation does not work

```
// Work fine!
pinTokyo = new Pin()
{
    Type = PinType.Place,
    Label = "Tokyo SKYTREE",
    Address = "Sumida-ku, Tokyo, Japan",
    Position = new Position(35.71d, 139.81d),
    Rotation = 92.3f
};

button1.Click += (s, e) =>
{
    pinTokyo.Rotation = 45f; // Does not work
}
```

## Improve pin rotation sample

![untitled2](https://cloud.githubusercontent.com/assets/401369/20223254/221ae4a4-a87c-11e6-8443-7ce3445ffcc4.gif)
