### PR TITLE
Add MoveCamera method

### DIFF
--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:maps="clr-namespace:Xamarin.Forms.GoogleMaps;assembly=Xamarin.Forms.GoogleMaps"
+    x:Class="XFGoogleMapSample.CameraPage"
+    Title="Camera Operations">
+    <ContentPage.Content>
+        <Grid
+            HorizontalOptions="Fill"
+            VerticalOptions="Fill">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="4*" />
+                <RowDefinition Height="6*" />
+            </Grid.RowDefinitions>
+
+            <ScrollView Grid.Row="0"
+                        Orientation="Vertical">
+
+                <StackLayout Orientation="Vertical">
+
+					<Button x:Name="buttonMoveToLatLng" Text="Move to LatLng" />
+
+                </StackLayout>
+            </ScrollView>
+
+            <maps:Map Grid.Row="1" x:Name="map"
+                      VerticalOptions="FillAndExpand" />
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
@@ -12,6 +12,7 @@
             VerticalOptions="Fill">
             <Grid.RowDefinitions>
                 <RowDefinition Height="4*" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="6*" />
             </Grid.RowDefinitions>
 
@@ -25,7 +26,9 @@
                 </StackLayout>
             </ScrollView>
 
-            <maps:Map Grid.Row="1" x:Name="map"
+			<Label Grid.Row="1" x:Name="labelStatus" />
+
+            <maps:Map Grid.Row="2" x:Name="map"
                       VerticalOptions="FillAndExpand" />
         </Grid>
     </ContentPage.Content>

--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml
@@ -21,12 +21,15 @@
 
                 <StackLayout Orientation="Vertical">
 
-					<Button x:Name="buttonMoveToLatLng" Text="Move to LatLng" />
+                    <Button x:Name="buttonMoveToPosition" Text="Move to LatLng" />
+                    <Button x:Name="buttonMoveToPositionZoom" Text="Move to LatLngZoom" />
+                    <Button x:Name="buttonMoveToBounds" Text="Move to LatLngBounds" />
+                    <Button x:Name="buttonMoveToCameraPosition" Text="Move to CameraPosition" />
 
                 </StackLayout>
             </ScrollView>
 
-			<Label Grid.Row="1" x:Name="labelStatus" />
+            <Label Grid.Row="1" x:Name="labelStatus" />
 
             <maps:Map Grid.Row="2" x:Name="map"
                       VerticalOptions="FillAndExpand" />

--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
@@ -12,15 +12,55 @@ namespace XFGoogleMapSample
         {
             InitializeComponent();
 
+            var pinMelbourne = new Pin() { Label = "Melbourne", Position = new Position(-37.971237, 144.492697) };
+            var pinNewyork = new Pin() { Label = "New york", Position = new Position(40.705311, -74.2581874) };
+            var pinLisboa = new Pin() { Label = "Lisboa", Position = new Position(38.7436057, -13.6426275) };
+            var pinParis = new Pin() { Label = "Paris", Position = new Position(48.8588377, 2.2775173) };
+            var pinTokyo = new Pin() { Label = "Tokyo", Position = new Position(35.7104, 139.8093) };
+            map.Pins.Add(pinMelbourne);
+            map.Pins.Add(pinNewyork);
+            map.Pins.Add(pinLisboa);
+            map.Pins.Add(pinParis);
+            map.Pins.Add(pinTokyo);
+
             map.CameraChanged += (sender, e) => 
             {
                 var p = e.Position;
                 labelStatus.Text = $"Lat={p.Target.Latitude:0.00}, Long={p.Target.Longitude:0.00}, Zoom={p.Zoom:0.00}, Bearing={p.Bearing:0.00}, Tilt={p.Tilt:0.00}";
             };
 
-            buttonMoveToLatLng.Clicked += async (sender, e) =>
+            // MoveToCamera with Position
+            buttonMoveToPosition.Clicked += async (sender, e) =>
             {
-                await map.MoveCamera(CameraUpdateFactory.NewLatLng(new Position(35.7104, 139.8093)));
+                await map.MoveCamera(CameraUpdateFactory.NewPosition(
+                    pinMelbourne.Position)); // Melbourne
+            };
+
+            // MoveToCamera with Position and Zoom
+            buttonMoveToPositionZoom.Clicked += async (sender, e) =>
+            {
+                await map.MoveCamera(CameraUpdateFactory.NewPositionZoom(
+                    pinNewyork.Position, 16d)); // New york
+            };
+
+            // MoveToCamera with Bounds
+            buttonMoveToBounds.Clicked += async (sender, e) =>
+            {
+                await map.MoveCamera(CameraUpdateFactory.NewBounds(
+                    new Bounds(pinLisboa.Position,  // Lisboa
+                               pinParis.Position),  // Paris
+                   50)); // 50px
+            };
+
+            // MoveToCamera with Bounds
+            buttonMoveToCameraPosition.Clicked += async (sender, e) =>
+            {
+                await map.MoveCamera(CameraUpdateFactory.NewCameraPosition(
+                    new CameraPosition(
+                        pinTokyo.Position, // Tokyo
+                        45d, // bearing(rotation)
+                        60d, // tilt
+                        17d)));
             };
         }
     }

--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
@@ -12,6 +12,12 @@ namespace XFGoogleMapSample
         {
             InitializeComponent();
 
+            map.CameraChanged += (sender, e) => 
+            {
+                var p = e.Position;
+                labelStatus.Text = $"Lat={p.Target.Latitude:0.00}, Long={p.Target.Longitude:0.00}, Zoom={p.Zoom:0.00}, Bearing={p.Bearing:0.00}, Tilt={p.Tilt:0.00}";
+            };
+
             buttonMoveToLatLng.Clicked += async (sender, e) =>
             {
                 await map.MoveCamera(CameraUpdateFactory.NewLatLng(new Position(35.7104, 139.8093)));

--- a/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/CameraPage.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using Xamarin.Forms.GoogleMaps;
+
+namespace XFGoogleMapSample
+{
+    public partial class CameraPage : ContentPage
+    {
+        public CameraPage()
+        {
+            InitializeComponent();
+
+            buttonMoveToLatLng.Clicked += async (sender, e) =>
+            {
+                await map.MoveCamera(CameraUpdateFactory.NewLatLng(new Position(35.7104, 139.8093)));
+            };
+        }
+    }
+}

--- a/XFGoogleMapSample/XFGoogleMapSample/MainPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/MainPage.xaml
@@ -14,6 +14,8 @@
 
 			<Button x:Name="buttonBasicMap"
 					Text="Basic Map" />
+			<Button x:Name="buttonCamera"
+					Text="Camera Control" />
 			<Button x:Name="buttonPins"
 					Text="Pins" />
 			<Button x:Name="buttonShapes"

--- a/XFGoogleMapSample/XFGoogleMapSample/MainPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/MainPage.xaml.cs
@@ -9,6 +9,7 @@ namespace XFGoogleMapSample
             InitializeComponent();
 
             buttonBasicMap.Clicked += (_, e) => Navigation.PushAsync(new BasicMapPage());
+            buttonCamera.Clicked += (_, e) => Navigation.PushAsync(new CameraPage());
             buttonPins.Clicked += (_, e) => Navigation.PushAsync(new PinsPage());
             buttonShapes.Clicked += (_, e) => Navigation.PushAsync(new ShapesPage());
             buttonTiles.Clicked += (_, e) => Navigation.PushAsync(new TilesPage());

--- a/XFGoogleMapSample/XFGoogleMapSample/XFGoogleMapSample.local.csproj
+++ b/XFGoogleMapSample/XFGoogleMapSample/XFGoogleMapSample.local.csproj
@@ -62,6 +62,9 @@
     <EmbeddedResource Include="GroundOverlaysPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Include="CameraPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">
@@ -100,6 +103,9 @@
     </Compile>
     <Compile Include="Extensions\ListExtensions.cs" />
     <Compile Include="Variables.cs" />
+    <Compile Include="CameraPage.xaml.cs">
+      <DependentUpon>CameraPage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraPositionExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraPositionExtensions.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.GoogleMaps.Android.Extensions
 
         public static GCameraPosition ToAndroid(this CameraPosition self)
         {
-            return new GCameraPosition(self.Target.ToLatLng(), self.Zoom, self.Tilt, self.Bearing);
+            return new GCameraPosition(self.Target.ToLatLng(), (float)self.Zoom, (float)self.Tilt, (float)self.Bearing);
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraPositionExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraPositionExtensions.cs
@@ -14,5 +14,10 @@ namespace Xamarin.Forms.GoogleMaps.Android.Extensions
                 self.Zoom
             );
         }
+
+        public static GCameraPosition ToAndroid(this CameraPosition self)
+        {
+            return new GCameraPosition(self.Target.ToLatLng(), self.Zoom, self.Tilt, self.Bearing);
+        }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.GoogleMaps.Android.Extensions
 {
     internal static class CameraUpdateExtensions
     {
-        public static GCameraUpdate ToAndroid(this CameraUpdate self)
+        public static GCameraUpdate ToAndroid(this CameraUpdate self, float scaledDensity)
         {
             switch (self.UpdateType)
             {
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.GoogleMaps.Android.Extensions
                 case CameraUpdateType.LatLngZoom:
                     return GCameraUpdateFactory.NewLatLngZoom(self.Position.ToLatLng(), (float) self.Zoom);
                 case CameraUpdateType.LatLngBounds:
-                    return GCameraUpdateFactory.NewLatLngBounds(self.Bounds.ToLatLngBounds(), self.Padding);
+                    return GCameraUpdateFactory.NewLatLngBounds(self.Bounds.ToLatLngBounds(), (int)(self.Padding * scaledDensity)); // TODO: convert from px to pt. Is this collect? (looks like same iOS Maps)
                 case CameraUpdateType.CameraPosition:
                     return GCameraUpdateFactory.NewCameraPosition(self.CameraPosition.ToAndroid());
                 default:

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using GCameraUpdateFactory = Android.Gms.Maps.CameraUpdateFactory;
+using GCameraUpdate = Android.Gms.Maps.CameraUpdate;
+using Xamarin.Forms.GoogleMaps.Internals;
+
+namespace Xamarin.Forms.GoogleMaps.Android.Extensions
+{
+    internal static class CameraUpdateExtensions
+    {
+        public static GCameraUpdate ToAndroid(this CameraUpdate self)
+        {
+            switch (self.UpdateType)
+            {
+                case CameraUpdateType.LatLng:
+                    return GCameraUpdateFactory.NewLatLng(self.Position.ToLatLng());
+                default:
+                    throw new ArgumentException($"{nameof(self)} UpdateType is not supported.");
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Extensions/CameraUpdateExtensions.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Forms.GoogleMaps.Android.Extensions
             {
                 case CameraUpdateType.LatLng:
                     return GCameraUpdateFactory.NewLatLng(self.Position.ToLatLng());
+                case CameraUpdateType.LatLngZoom:
+                    return GCameraUpdateFactory.NewLatLngZoom(self.Position.ToLatLng(), (float) self.Zoom);
+                case CameraUpdateType.LatLngBounds:
+                    return GCameraUpdateFactory.NewLatLngBounds(self.Bounds.ToLatLngBounds(), self.Padding);
+                case CameraUpdateType.CameraPosition:
+                    return GCameraUpdateFactory.NewCameraPosition(self.CameraPosition.ToAndroid());
                 default:
                     throw new ArgumentException($"{nameof(self)} UpdateType is not supported.");
             }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
@@ -1,0 +1,68 @@
+﻿using Android.Gms.Maps;
+using Android.Gms.Maps.Model;
+using Java.Lang;
+using Xamarin.Forms.GoogleMaps.Android.Extensions;
+using Xamarin.Forms.GoogleMaps.Internals;
+
+using GCameraUpdateFactory = Android.Gms.Maps.CameraUpdateFactory;
+
+namespace Xamarin.Forms.GoogleMaps.Logics.Android
+{
+    internal sealed class CameraLogic : BaseCameraLogic<GoogleMap>
+    {
+        private Map _map;
+        private GoogleMap _nativeMap;
+
+        public override void Register(Map map, GoogleMap nativeMap)
+        {
+            _map = map;
+            _nativeMap = nativeMap;
+
+            _map.OnMoveToRegion = OnMoveToRegionRequest;
+            _map.OnMoveCamera = OnMoveCameraRequest;
+        }
+
+        public override void Unregister()
+        {
+            if (_map != null)
+            {
+                _map.OnMoveCamera = null;
+                _map.OnMoveToRegion = null;
+            }
+        }
+
+        public override void OnMoveToRegionRequest(MoveToRegionMessage m)
+        {
+            MoveToRegion(m.Span, m.Animate);
+        }
+
+        public void MoveToRegion(MapSpan span, bool animate)
+        {
+            if (_nativeMap == null)
+                return;
+
+            span = span.ClampLatitude(85, -85);
+            var ne = new LatLng(span.Center.Latitude + span.LatitudeDegrees / 2, span.Center.Longitude + span.LongitudeDegrees / 2);
+            var sw = new LatLng(span.Center.Latitude - span.LatitudeDegrees / 2, span.Center.Longitude - span.LongitudeDegrees / 2);
+            var update = GCameraUpdateFactory.NewLatLngBounds(new LatLngBounds(sw, ne), 0);
+
+            try
+            {
+                if (animate)
+                    _nativeMap.AnimateCamera(update);
+                else
+                    _nativeMap.MoveCamera(update);
+            }
+            catch (IllegalStateException exc)
+            {
+                System.Diagnostics.Debug.WriteLine("MoveToRegion exception: " + exc);
+            }
+        }
+
+        public override void OnMoveCameraRequest(CameraUpdateMessage m)
+        {
+            _nativeMap.MoveCamera(m.Update.ToAndroid());
+            m.Callback.OnFinished();
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
@@ -10,9 +10,6 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
 {
     internal sealed class CameraLogic : BaseCameraLogic<GoogleMap>
     {
-        private Map _map;
-        private GoogleMap _nativeMap;
-
         public override void Register(Map map, GoogleMap nativeMap)
         {
             _map = map;
@@ -20,15 +17,6 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
 
             _map.OnMoveToRegion = OnMoveToRegionRequest;
             _map.OnMoveCamera = OnMoveCameraRequest;
-        }
-
-        public override void Unregister()
-        {
-            if (_map != null)
-            {
-                _map.OnMoveCamera = null;
-                _map.OnMoveToRegion = null;
-            }
         }
 
         public override void OnMoveToRegionRequest(MoveToRegionMessage m)

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CameraLogic.cs
@@ -10,21 +10,12 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
 {
     internal sealed class CameraLogic : BaseCameraLogic<GoogleMap>
     {
-        public override void Register(Map map, GoogleMap nativeMap)
-        {
-            _map = map;
-            _nativeMap = nativeMap;
-
-            _map.OnMoveToRegion = OnMoveToRegionRequest;
-            _map.OnMoveCamera = OnMoveCameraRequest;
-        }
-
         public override void OnMoveToRegionRequest(MoveToRegionMessage m)
         {
             MoveToRegion(m.Span, m.Animate);
         }
 
-        public void MoveToRegion(MapSpan span, bool animate)
+        internal void MoveToRegion(MapSpan span, bool animate)
         {
             if (_nativeMap == null)
                 return;
@@ -49,7 +40,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
 
         public override void OnMoveCameraRequest(CameraUpdateMessage m)
         {
-            _nativeMap.MoveCamera(m.Update.ToAndroid());
+            _nativeMap.MoveCamera(m.Update.ToAndroid(ScaledDensity));
             m.Callback.OnFinished();
         }
     }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -8,7 +8,6 @@ using Xamarin.Forms.Platform.Android;
 using Math = System.Math;
 using Android.Util;
 using Android.App;
-using Xamarin.Forms.GoogleMaps.Internals;
 using Xamarin.Forms.GoogleMaps.Logics.Android;
 using Xamarin.Forms.GoogleMaps.Logics;
 using Xamarin.Forms.GoogleMaps.Android.Extensions;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -15,6 +15,7 @@ using Xamarin.Forms.GoogleMaps.Android.Extensions;
 using Android.Widget;
 using Android.Views;
 
+using GCameraUpdateFactory = Android.Gms.Maps.CameraUpdateFactory;
 using GCameraPosition = Android.Gms.Maps.Model.CameraPosition;
 
 namespace Xamarin.Forms.GoogleMaps.Android
@@ -99,6 +100,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
             if (e.OldElement != null)
             {
                 var oldMapModel = (Map)e.OldElement;
+                Map.OnMoveCamera = null;
                 Map.OnMoveToRegion = null;
 
                 var oldGoogleMap = await oldMapView.GetGoogleMapAsync();
@@ -121,6 +123,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
             }
 
             Map.OnMoveToRegion = ((IMapRequestDelegate)this).OnMoveToRegion;
+            Map.OnMoveCamera = ((IMapRequestDelegate)this).OnMoveCamera;
 
             NativeMap = await ((MapView)Control).GetGoogleMapAsync();
             OnMapReady(NativeMap);
@@ -169,7 +172,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
             span = span.ClampLatitude(85, -85);
             var ne = new LatLng(span.Center.Latitude + span.LatitudeDegrees / 2, span.Center.Longitude + span.LongitudeDegrees / 2);
             var sw = new LatLng(span.Center.Latitude - span.LatitudeDegrees / 2, span.Center.Longitude - span.LongitudeDegrees / 2);
-            var update = CameraUpdateFactory.NewLatLngBounds(new LatLngBounds(sw, ne), 0);
+            var update = GCameraUpdateFactory.NewLatLngBounds(new LatLngBounds(sw, ne), 0);
 
             try
             {
@@ -182,6 +185,12 @@ namespace Xamarin.Forms.GoogleMaps.Android
             {
                 System.Diagnostics.Debug.WriteLine("MoveToRegion exception: " + exc);
             }
+        }
+
+        void IMapRequestDelegate.OnMoveCamera(CameraUpdateMessage m)
+        {
+            NativeMap.MoveCamera(m.Update.ToAndroid());
+            m.Callback.OnFinished();
         }
 
         protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -339,7 +348,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
 
                 if (this.Map != null)
                 {
-                    //MessagingCenter.Unsubscribe<Map, MoveToRegionMessage>(this, MoveMessageName);
+                    Map.OnMoveCamera = null;
                     Map.OnMoveToRegion = null;
                 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -94,6 +94,8 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 activity.WindowManager.DefaultDisplay.GetMetrics(metrics);
                 foreach (var logic in _logics)
                     logic.ScaledDensity = metrics.ScaledDensity;
+
+                _cameraLogic.ScaledDensity = metrics.ScaledDensity;
             }
 
             if (e.OldElement != null)

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Xamarin.Forms.GoogleMaps.Android.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Xamarin.Forms.GoogleMaps.Android.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Extensions\BoundsExtensions.cs" />
     <Compile Include="Extensions\MapViewExtensions.cs" />
     <Compile Include="Extensions\CameraPositionExtensions.cs" />
+    <Compile Include="Extensions\CameraUpdateExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Xamarin.Forms.GoogleMaps.Android.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Xamarin.Forms.GoogleMaps.Android.csproj
@@ -91,6 +91,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Logics\CameraLogic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\GobalAssemblyInfo.cs" />
     <Compile Include="FormsGoogleMaps.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Extensions/BoundsExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Extensions/BoundsExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Devices.Geolocation;
+
+namespace Xamarin.Forms.GoogleMaps.UWP.Extensions
+{
+    internal static class BoundsExtensions
+    {
+        public static GeoboundingBox ToGeoboundingBox(this Bounds self)
+        {
+            return new GeoboundingBox(
+                self.NorthWest.ToBasicGeoposition(), 
+                self.SouthEast.ToBasicGeoposition());
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Extensions/PositionExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Extensions/PositionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Devices.Geolocation;
+
+namespace Xamarin.Forms.GoogleMaps.UWP.Extensions
+{
+    internal static class PositionExtensions
+    {
+        public static BasicGeoposition ToBasicGeoposition(this Position self)
+        {
+            return new BasicGeoposition()
+            {
+                Latitude = self.Latitude,
+                Longitude = self.Longitude
+            };
+        }
+
+        public static Geopoint ToGeopoint(this Position self)
+        {
+            return new Geopoint(self.ToBasicGeoposition());
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
@@ -43,17 +43,19 @@ namespace Xamarin.Forms.GoogleMaps.UWP.Logics
                     break;
                 case CameraUpdateType.LatLngZoom:
                     _nativeMap.Center = m.Update.Position.ToGeopoint();
-                    await _nativeMap.TryZoomToAsync(m.Update.Zoom);
+                    _nativeMap.ZoomLevel = m.Update.Zoom;
                     break;
                 case CameraUpdateType.LatLngBounds:
                     await _nativeMap.TrySetViewBoundsAsync(
                         m.Update.Bounds.ToGeoboundingBox(), null, MapAnimationKind.None);
                     break;
                 case CameraUpdateType.CameraPosition:
-                    _nativeMap.Center = m.Update.CameraPosition.Target.ToGeopoint();
-                    await _nativeMap.TryRotateAsync(m.Update.CameraPosition.Bearing);
-                    await _nativeMap.TryTiltToAsync(m.Update.CameraPosition.Tilt);
-                    await _nativeMap.TryZoomToAsync(m.Update.CameraPosition.Zoom);
+                    await _nativeMap.TrySetViewAsync(
+                        m.Update.CameraPosition.Target.ToGeopoint(),
+                        m.Update.CameraPosition.Zoom,
+                        m.Update.CameraPosition.Bearing,
+                        m.Update.CameraPosition.Tilt,
+                        MapAnimationKind.None);
                     break;
                 default:
                     break;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
@@ -11,7 +11,7 @@ using Xamarin.Forms.GoogleMaps.UWP.Extensions;
 
 namespace Xamarin.Forms.GoogleMaps.UWP.Logics
 {
-    internal class CameraLogic : BaseCameraLogic<MapControl>
+    internal sealed class CameraLogic : BaseCameraLogic<MapControl>
     {
         public async override void OnMoveToRegionRequest(MoveToRegionMessage m)
         {

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
@@ -7,6 +7,7 @@ using Windows.Devices.Geolocation;
 using Windows.UI.Xaml.Controls.Maps;
 using Xamarin.Forms.GoogleMaps.Internals;
 using Xamarin.Forms.GoogleMaps.Logics;
+using Xamarin.Forms.GoogleMaps.UWP.Extensions;
 
 namespace Xamarin.Forms.GoogleMaps.UWP.Logics
 {
@@ -33,9 +34,32 @@ namespace Xamarin.Forms.GoogleMaps.UWP.Logics
             await _nativeMap.TrySetViewBoundsAsync(boundingBox, null, animation);
         }
 
-        public override void OnMoveCameraRequest(CameraUpdateMessage m)
+        public async override void OnMoveCameraRequest(CameraUpdateMessage m)
         {
-            throw new NotImplementedException();
+            switch (m.Update.UpdateType)
+            {
+                case CameraUpdateType.LatLng:
+                    _nativeMap.Center = m.Update.Position.ToGeopoint();
+                    break;
+                case CameraUpdateType.LatLngZoom:
+                    _nativeMap.Center = m.Update.Position.ToGeopoint();
+                    await _nativeMap.TryZoomToAsync(m.Update.Zoom);
+                    break;
+                case CameraUpdateType.LatLngBounds:
+                    await _nativeMap.TrySetViewBoundsAsync(
+                        m.Update.Bounds.ToGeoboundingBox(), null, MapAnimationKind.None);
+                    break;
+                case CameraUpdateType.CameraPosition:
+                    _nativeMap.Center = m.Update.CameraPosition.Target.ToGeopoint();
+                    await _nativeMap.TryRotateAsync(m.Update.CameraPosition.Bearing);
+                    await _nativeMap.TryTiltToAsync(m.Update.CameraPosition.Tilt);
+                    await _nativeMap.TryZoomToAsync(m.Update.CameraPosition.Zoom);
+                    break;
+                default:
+                    break;
+            }
+
+            m.Callback.OnFinished();
         }
 
     }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Devices.Geolocation;
+using Windows.UI.Xaml.Controls.Maps;
+using Xamarin.Forms.GoogleMaps.Internals;
+using Xamarin.Forms.GoogleMaps.Logics;
+
+namespace Xamarin.Forms.GoogleMaps.UWP.Logics
+{
+    internal class CameraLogic : BaseCameraLogic<MapControl>
+    {
+        public async override void OnMoveToRegionRequest(MoveToRegionMessage m)
+        {
+            await MoveToRegion(m.Span, m.Animate ? MapAnimationKind.Bow : MapAnimationKind.None);
+        }
+
+        internal async Task MoveToRegion(MapSpan span, MapAnimationKind animation = MapAnimationKind.Bow)
+        {
+            var nw = new BasicGeoposition
+            {
+                Latitude = span.Center.Latitude + span.LatitudeDegrees / 2,
+                Longitude = span.Center.Longitude - span.LongitudeDegrees / 2
+            };
+            var se = new BasicGeoposition
+            {
+                Latitude = span.Center.Latitude - span.LatitudeDegrees / 2,
+                Longitude = span.Center.Longitude + span.LongitudeDegrees / 2
+            };
+            var boundingBox = new GeoboundingBox(nw, se);
+            await _nativeMap.TrySetViewBoundsAsync(boundingBox, null, animation);
+        }
+
+        public override void OnMoveCameraRequest(CameraUpdateMessage m)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -13,6 +13,7 @@ using Xamarin.Forms.GoogleMaps.Extensions.UWP;
 using Xamarin.Forms.GoogleMaps.Internals;
 using Xamarin.Forms.GoogleMaps.Logics;
 using Xamarin.Forms.GoogleMaps.Logics.UWP;
+using Xamarin.Forms.GoogleMaps.UWP.Logics;
 #if WINDOWS_UWP
 using Xamarin.Forms.Platform.UWP;
 
@@ -29,8 +30,10 @@ namespace Xamarin.Forms.GoogleMaps.UWP
 namespace Xamarin.Forms.Maps.WinRT
 #endif
 {
-    public class MapRenderer : ViewRenderer<Map, MapControl>, IMapRequestDelegate
+    public class MapRenderer : ViewRenderer<Map, MapControl>
     {
+        private readonly CameraLogic _cameraLogic = new CameraLogic();
+
         private Map Map
         {
             get { return Element as Map; }
@@ -61,7 +64,7 @@ namespace Xamarin.Forms.Maps.WinRT
             if (e.OldElement != null)
             {
                 var mapModel = e.OldElement;
-                Map.OnMoveToRegion = null;
+                _cameraLogic.Unregister();
 
                 if (oldMapView != null)
                 {
@@ -83,7 +86,7 @@ namespace Xamarin.Forms.Maps.WinRT
                     Control.ActualCameraChanged += OnActualCameraChanged;
                 }
 
-                Map.OnMoveToRegion = ((IMapRequestDelegate)this).OnMoveToRegion;
+                _cameraLogic.Register(Map, NativeMap);
 
                 UpdateMapType();
                 UpdateHasScrollEnabled();
@@ -150,7 +153,7 @@ namespace Xamarin.Forms.Maps.WinRT
             {
                 _disposed = true;
 
-                Map.OnMoveToRegion = null;
+                _cameraLogic.Unregister();
             }
             base.Dispose(disposing);
         }
@@ -176,22 +179,6 @@ namespace Xamarin.Forms.Maps.WinRT
                 Control.Children.Remove(_userPositionCircle);
         }
 
-        async Task MoveToRegion(MapSpan span, MapAnimationKind animation = MapAnimationKind.Bow)
-        {
-            var nw = new BasicGeoposition
-            {
-                Latitude = span.Center.Latitude + span.LatitudeDegrees / 2,
-                Longitude = span.Center.Longitude - span.LongitudeDegrees / 2
-            };
-            var se = new BasicGeoposition
-            {
-                Latitude = span.Center.Latitude - span.LatitudeDegrees / 2,
-                Longitude = span.Center.Longitude + span.LongitudeDegrees / 2
-            };
-            var boundingBox = new GeoboundingBox(nw, se);
-            await Control.TrySetViewBoundsAsync(boundingBox, null, animation);
-        }
-
         async Task UpdateVisibleRegion()
         {
             if (Control == null || Element == null)
@@ -199,7 +186,7 @@ namespace Xamarin.Forms.Maps.WinRT
 
             if (!_firstZoomLevelChangeFired)
             {
-                await MoveToRegion(Element.LastMoveToRegion, MapAnimationKind.None);
+                await _cameraLogic.MoveToRegion(Element.LastMoveToRegion, MapAnimationKind.None);
                 _firstZoomLevelChangeFired = true;
                 return;
             }
@@ -292,11 +279,6 @@ namespace Xamarin.Forms.Maps.WinRT
         void UpdateHasScrollEnabled()
         {
             Control.PanInteractionMode = Element.HasScrollEnabled ? MapPanInteractionMode.Auto : MapPanInteractionMode.Disabled;
-        }
-
-        async void IMapRequestDelegate.OnMoveToRegion(MoveToRegionMessage m)
-        {
-            await MoveToRegion(m.Span, m.Animate ? MapAnimationKind.Bow : MapAnimationKind.None);
         }
 #else
         void UpdateHasZoomEnabled()

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Maps.WinRT
             var camera = args.Camera;
             var pos = new CameraPosition(
                 camera.Location.Position.ToPosition(),
-                camera.Roll,
+                camera.Heading,
                 camera.Pitch,
                 sender.ZoomLevel);
             Map.SendCameraChanged(pos);

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Xamarin.Forms.GoogleMaps.UWP.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Xamarin.Forms.GoogleMaps.UWP.csproj
@@ -108,7 +108,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\BitmapDescriptorExtensions.cs" />
+    <Compile Include="Extensions\BoundsExtensions.cs" />
     <Compile Include="Extensions\LngLatExtensions.cs" />
+    <Compile Include="Extensions\PositionExtensions.cs" />
     <Compile Include="FormsGoogleMap.cs" />
     <Compile Include="GeocoderBackend.cs" />
     <Compile Include="Logics\CameraLogic.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Xamarin.Forms.GoogleMaps.UWP.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Xamarin.Forms.GoogleMaps.UWP.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Extensions\LngLatExtensions.cs" />
     <Compile Include="FormsGoogleMap.cs" />
     <Compile Include="GeocoderBackend.cs" />
+    <Compile Include="Logics\CameraLogic.cs" />
     <Compile Include="Logics\PinLogic.cs" />
     <Compile Include="Logics\TileLayerLogic.cs" />
     <Compile Include="MapRenderer.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/CameraPositionExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/CameraPositionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Google.Maps;
-
+using Xamarin.Forms.GoogleMaps.Extensions.iOS;
 using GCameraPosition = Google.Maps.CameraPosition;
 
 namespace Xamarin.Forms.GoogleMaps.iOS.Extensions
@@ -15,6 +15,11 @@ namespace Xamarin.Forms.GoogleMaps.iOS.Extensions
                     self.ViewingAngle,
                     self.Zoom
             );
+        }
+
+        public static GCameraPosition ToIOS(this CameraPosition self)
+        {
+            return new GCameraPosition(self.Target.ToCoord(), (float)self.Zoom, (float)self.Bearing, (float)self.Tilt);
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/CameraUpdateExtensions.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/CameraUpdateExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Xamarin.Forms.GoogleMaps.Extensions.iOS;
+using Xamarin.Forms.GoogleMaps.Internals;
+
+using GCameraUpdate = Google.Maps.CameraUpdate;
+
+namespace Xamarin.Forms.GoogleMaps.iOS.Extensions
+{
+    internal static class CameraUpdateExtensions
+    {
+        public static GCameraUpdate ToIOS(this CameraUpdate self)
+        {
+            switch (self.UpdateType)
+            {
+                case CameraUpdateType.LatLng:
+                    return GCameraUpdate.SetTarget(self.Position.ToCoord());
+                case CameraUpdateType.LatLngZoom:
+                    return GCameraUpdate.SetTarget(self.Position.ToCoord(), (float)self.Zoom);
+                case CameraUpdateType.LatLngBounds:
+                    return GCameraUpdate.FitBounds(self.Bounds.ToCoordinateBounds(), self.Padding);
+                case CameraUpdateType.CameraPosition:
+                    return GCameraUpdate.SetCamera(self.CameraPosition.ToIOS());
+                default:
+                    throw new ArgumentException($"{nameof(self)} UpdateType is not supported.");
+            }
+        }
+
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
@@ -1,22 +1,37 @@
-﻿using Google.Maps;
+﻿using CoreLocation;
+using Google.Maps;
+using Xamarin.Forms.GoogleMaps.iOS.Extensions;
 using Xamarin.Forms.GoogleMaps.Internals;
+
+using GCameraUpdate = Google.Maps.CameraUpdate;
 
 namespace Xamarin.Forms.GoogleMaps.Logics.iOS
 {
     internal sealed class CameraLogic : BaseCameraLogic<MapView>
     {
-        public override void Register(Map map, MapView nativeMap)
-        {
-            _map = map;
-            _nativeMap = nativeMap;
-        }
-
         public override void OnMoveToRegionRequest(MoveToRegionMessage m)
         {
+            MoveToRegion(m.Span, m.Animate);
+        }
+
+        internal void MoveToRegion(MapSpan mapSpan, bool animated = true)
+        {
+            Position center = mapSpan.Center;
+            var halfLat = mapSpan.LatitudeDegrees / 2d;
+            var halfLong = mapSpan.LongitudeDegrees / 2d;
+            var mapRegion = new CoordinateBounds(new CLLocationCoordinate2D(center.Latitude - halfLat, center.Longitude - halfLong),
+                new CLLocationCoordinate2D(center.Latitude + halfLat, center.Longitude + halfLong));
+
+            if (animated)
+                _nativeMap.Animate(GCameraUpdate.FitBounds(mapRegion));
+            else
+                _nativeMap.MoveCamera(GCameraUpdate.FitBounds(mapRegion));
         }
 
         public override void OnMoveCameraRequest(CameraUpdateMessage m)
         {
+            _nativeMap.MoveCamera(m.Update.ToIOS());
+            m.Callback.OnFinished();
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
@@ -1,0 +1,22 @@
+﻿using Google.Maps;
+using Xamarin.Forms.GoogleMaps.Internals;
+
+namespace Xamarin.Forms.GoogleMaps.Logics.iOS
+{
+    internal sealed class CameraLogic : BaseCameraLogic<MapView>
+    {
+        public override void Register(Map map, MapView nativeMap)
+        {
+            _map = map;
+            _nativeMap = nativeMap;
+        }
+
+        public override void OnMoveToRegionRequest(MoveToRegionMessage m)
+        {
+        }
+
+        public override void OnMoveCameraRequest(CameraUpdateMessage m)
+        {
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -2,9 +2,7 @@
 using System.ComponentModel;
 using Xamarin.Forms.Platform.iOS;
 using Google.Maps;
-using CoreLocation;
 using System.Drawing;
-using Xamarin.Forms.GoogleMaps.Internals;
 using Xamarin.Forms.GoogleMaps.Logics.iOS;
 using Xamarin.Forms.GoogleMaps.Logics;
 using Xamarin.Forms.GoogleMaps.iOS.Extensions;
@@ -46,12 +44,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
         {
             if (disposing)
             {
-
-                if (Element != null)
-                {
-                    _cameraLogic.Unregister();
-                    var mapModel = (Map)Element;
-                }
+                _cameraLogic.Unregister();
 
                 foreach (var logic in _logics)
                     logic.Unregister(NativeMap, Map);
@@ -107,7 +100,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                 _cameraLogic.Register(Map, NativeMap);
 
                 if (mapModel.LastMoveToRegion != null)
-                    MoveToRegion(mapModel.LastMoveToRegion, false);
+                    _cameraLogic.MoveToRegion(mapModel.LastMoveToRegion, false);
 
                 UpdateMapType();
                 UpdateIsShowingUser();
@@ -182,7 +175,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
 
             if (_shouldUpdateRegion)
             {
-                MoveToRegion(((Map)Element).LastMoveToRegion, false);
+                _cameraLogic.MoveToRegion(((Map)Element).LastMoveToRegion, false);
                 _shouldUpdateRegion = false;
             }
 
@@ -219,20 +212,6 @@ namespace Xamarin.Forms.GoogleMaps.iOS
         bool DidTapMyLocation(MapView mapView)
         {
             return Map.SendMyLocationClicked();
-        }
-
-        void MoveToRegion(MapSpan mapSpan, bool animated = true)
-        {
-            Position center = mapSpan.Center;
-            var halfLat = mapSpan.LatitudeDegrees / 2d;
-            var halfLong = mapSpan.LongitudeDegrees / 2d;
-            var mapRegion = new CoordinateBounds(new CLLocationCoordinate2D(center.Latitude - halfLat, center.Longitude - halfLong),
-                                                new CLLocationCoordinate2D(center.Latitude + halfLat, center.Longitude + halfLong));
-
-            if (animated)
-                ((MapView)Control).Animate(GCameraUpdate.FitBounds(mapRegion));
-            else
-                ((MapView)Control).MoveCamera(GCameraUpdate.FitBounds(mapRegion));
         }
 
         void UpdateHasScrollEnabled()

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -10,6 +10,8 @@ using Xamarin.Forms.GoogleMaps.Logics;
 using Xamarin.Forms.GoogleMaps.iOS.Extensions;
 using UIKit;
 
+using GCameraUpdate = Google.Maps.CameraUpdate;
+
 namespace Xamarin.Forms.GoogleMaps.iOS
 {
     public class MapRenderer : ViewRenderer
@@ -19,6 +21,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
         protected MapView NativeMap => (MapView)Control;
         protected Map Map => (Map)Element;
 
+        readonly CameraLogic _cameraLogic = new CameraLogic();
         readonly BaseLogic<MapView>[] _logics;
 
         public MapRenderer()
@@ -46,8 +49,8 @@ namespace Xamarin.Forms.GoogleMaps.iOS
 
                 if (Element != null)
                 {
+                    _cameraLogic.Unregister();
                     var mapModel = (Map)Element;
-                    Map.OnMoveToRegion = null;
                 }
 
                 foreach (var logic in _logics)
@@ -84,7 +87,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
             var oldMapView = (MapView)Control;
             if (e.OldElement != null)
             {
-                Map.OnMoveToRegion = null;
+                _cameraLogic.Unregister();
             }
 
             if (e.NewElement != null)
@@ -101,8 +104,8 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                     mkMapView.DidTapMyLocationButton = DidTapMyLocation;
                 }
 
+                _cameraLogic.Register(Map, NativeMap);
 
-                Map.OnMoveToRegion = ((IMapRequestDelegate)this).OnMoveToRegion;
                 if (mapModel.LastMoveToRegion != null)
                     MoveToRegion(mapModel.LastMoveToRegion, false);
 
@@ -227,9 +230,9 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                                                 new CLLocationCoordinate2D(center.Latitude + halfLat, center.Longitude + halfLong));
 
             if (animated)
-                ((MapView)Control).Animate(CameraUpdate.FitBounds(mapRegion));
+                ((MapView)Control).Animate(GCameraUpdate.FitBounds(mapRegion));
             else
-                ((MapView)Control).MoveCamera(CameraUpdate.FitBounds(mapRegion));
+                ((MapView)Control).MoveCamera(GCameraUpdate.FitBounds(mapRegion));
         }
 
         void UpdateHasScrollEnabled()

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -12,7 +12,7 @@ using UIKit;
 
 namespace Xamarin.Forms.GoogleMaps.iOS
 {
-    public class MapRenderer : ViewRenderer, IMapRequestDelegate
+    public class MapRenderer : ViewRenderer
     {
         bool _shouldUpdateRegion = true;
 
@@ -273,11 +273,5 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                     throw new ArgumentOutOfRangeException();
             }
         }
-
-        void IMapRequestDelegate.OnMoveToRegion(MoveToRegionMessage m)
-        {
-            MoveToRegion(m.Span, m.Animate);
-        }
-
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Xamarin.Build.Download.0.2.2\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.2.2\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
@@ -74,6 +74,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Logics\CameraLogic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FormsGoogleMaps.cs" />
     <Compile Include="MapRenderer.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
@@ -74,6 +74,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\CameraUpdateExtensions.cs" />
     <Compile Include="Logics\CameraLogic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FormsGoogleMaps.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/AnimationStatus.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/AnimationStatus.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps
+{
+    public enum AnimationStatus
+    {
+        Finished,
+        Canceled
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Bounds.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Bounds.cs
@@ -7,6 +7,20 @@ namespace Xamarin.Forms.GoogleMaps
     {
         public Position SouthWest { get; }
         public Position NorthEast { get; }
+        public Position SouthEast
+        {
+            get
+            {
+                return new Position(SouthWest.Latitude, NorthEast.Longitude);
+            }
+        }
+
+        public Position NorthWest {
+            get
+            {
+                return new Position(NorthEast.Latitude, SouthWest.Longitude);
+            }
+        }
 
         public Position Center
         {

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraPosition.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraPosition.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.GoogleMaps
         public double Tilt { get; }
         public double Zoom { get; }
 
-        internal CameraPosition(Position target, double bearing, double tilt, double zoom)
+        public CameraPosition(Position target, double bearing, double tilt, double zoom)
         {
             Target = target;
             Bearing = bearing;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdate.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdate.cs
@@ -1,0 +1,16 @@
+using Xamarin.Forms.GoogleMaps.Internals;
+
+namespace Xamarin.Forms.GoogleMaps
+{
+    public sealed class CameraUpdate
+    {
+        internal CameraUpdateType UpdateType { get; }
+        internal Position Position { get; }
+
+        internal CameraUpdate(Position position)
+        {
+            UpdateType = CameraUpdateType.LatLng;
+            Position = position;
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdate.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdate.cs
@@ -6,11 +6,36 @@ namespace Xamarin.Forms.GoogleMaps
     {
         internal CameraUpdateType UpdateType { get; }
         internal Position Position { get; }
+        internal double Zoom { get; }
+        internal Bounds Bounds { get; }
+        internal int Padding { get; }
+        internal CameraPosition CameraPosition { get; }
 
         internal CameraUpdate(Position position)
         {
             UpdateType = CameraUpdateType.LatLng;
             Position = position;
         }
+
+        internal CameraUpdate(Position position, double zoomLv)
+        {
+            UpdateType = CameraUpdateType.LatLngZoom;
+            Position = position;
+            Zoom = zoomLv;
+        }
+
+        internal CameraUpdate(Bounds bounds, int padding)
+        {
+            UpdateType = CameraUpdateType.LatLngBounds;
+            Bounds = bounds;
+            Padding = padding;
+        }
+
+        internal CameraUpdate(CameraPosition cameraPosition)
+        {
+            UpdateType = CameraUpdateType.CameraPosition;
+            CameraPosition = cameraPosition;
+        }
+
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
@@ -7,5 +7,20 @@ namespace Xamarin.Forms.GoogleMaps
         {
             return new CameraUpdate(position);
         }
+
+        public static CameraUpdate NewLatLngZoom(Position position, double zoomLv)
+        {
+            return new CameraUpdate(position, zoomLv);
+        }
+
+        public static CameraUpdate NewLatLngBounds(Bounds bounds, int padding)
+        {
+            return new CameraUpdate(bounds, padding);
+        }
+
+        public static CameraUpdate NewCameraPosition(CameraPosition cameraPosition)
+        {
+            return new CameraUpdate(cameraPosition);
+        }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps
+{
+    public static class CameraUpdateFactory
+    {
+        public static CameraUpdate NewLatLng(Position position)
+        {
+            return new CameraUpdate(position);
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/CameraUpdateFactory.cs
@@ -3,17 +3,17 @@ namespace Xamarin.Forms.GoogleMaps
 {
     public static class CameraUpdateFactory
     {
-        public static CameraUpdate NewLatLng(Position position)
+        public static CameraUpdate NewPosition(Position position)
         {
             return new CameraUpdate(position);
         }
 
-        public static CameraUpdate NewLatLngZoom(Position position, double zoomLv)
+        public static CameraUpdate NewPositionZoom(Position position, double zoomLv)
         {
             return new CameraUpdate(position, zoomLv);
         }
 
-        public static CameraUpdate NewLatLngBounds(Bounds bounds, int padding)
+        public static CameraUpdate NewBounds(Bounds bounds, int padding)
         {
             return new CameraUpdate(bounds, padding);
         }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateMessage.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateMessage.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps.Internals
+{
+    internal sealed class CameraUpdateMessage
+    {
+        public CameraUpdate Update { get; }
+
+        public IAnimationCallback Callback { get; }
+
+        public CameraUpdateMessage(CameraUpdate update, IAnimationCallback callback)
+        {
+            Update = update;
+            Callback = callback;
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateType.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateType.cs
@@ -4,5 +4,8 @@ namespace Xamarin.Forms.GoogleMaps.Internals
     internal enum CameraUpdateType
     {
         LatLng,
+        LatLngZoom,
+        LatLngBounds,
+        CameraPosition
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateType.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/CameraUpdateType.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps.Internals
+{
+    internal enum CameraUpdateType
+    {
+        LatLng,
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/DelegateAnimationCallback.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/DelegateAnimationCallback.cs
@@ -1,0 +1,25 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps.Internals
+{
+    internal class DelegateAnimationCallback : IAnimationCallback
+    {
+        readonly Action _onFinished;
+        readonly Action _onCanceled;
+
+        public DelegateAnimationCallback(Action onFinished, Action onCanceled)
+        {
+            _onFinished = onFinished;
+            _onCanceled = onCanceled;
+        }
+
+        public void OnFinished()
+        {
+            _onFinished?.Invoke();
+        }
+
+        public void OnCanceled()
+        {
+            _onCanceled?.Invoke();
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IAnimationCallback.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IAnimationCallback.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Xamarin.Forms.GoogleMaps.Internals
+{
+    internal interface IAnimationCallback
+    {
+        void OnFinished();
+        void OnCanceled();
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IMapRequestDelegate.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IMapRequestDelegate.cs
@@ -3,7 +3,7 @@ namespace Xamarin.Forms.GoogleMaps.Internals
 {
     internal interface IMapRequestDelegate
     {
-        void OnMoveToRegion(MoveToRegionMessage m);
-        void OnMoveCamera(CameraUpdateMessage m);
+        void OnMoveToRegionRequest(MoveToRegionMessage m);
+        void OnMoveCameraRequest(CameraUpdateMessage m);
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IMapRequestDelegate.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Internals/IMapRequestDelegate.cs
@@ -4,5 +4,6 @@ namespace Xamarin.Forms.GoogleMaps.Internals
     internal interface IMapRequestDelegate
     {
         void OnMoveToRegion(MoveToRegionMessage m);
+        void OnMoveCamera(CameraUpdateMessage m);
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
@@ -7,7 +7,16 @@ namespace Xamarin.Forms.GoogleMaps.Logics
         protected Map _map;
         protected TNativeMap _nativeMap;
 
-        public abstract void Register(Map map, TNativeMap nativeMap);
+        public float ScaledDensity { get; internal set; }
+
+        public void Register(Map map, TNativeMap nativeMap)
+        {
+            _map = map;
+            _nativeMap = nativeMap;
+
+            _map.OnMoveToRegion = OnMoveToRegionRequest;
+            _map.OnMoveCamera = OnMoveCameraRequest;
+        }
 
         public void Unregister()
         {

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
@@ -4,8 +4,19 @@ namespace Xamarin.Forms.GoogleMaps.Logics
 {
     internal abstract class BaseCameraLogic<TNativeMap> : IMapRequestDelegate
     {
+        protected Map _map;
+        protected TNativeMap _nativeMap;
+
         public abstract void Register(Map map, TNativeMap nativeMap);
-        public abstract void Unregister();
+
+        public void Unregister()
+        {
+            if (_map != null)
+            {
+                _map.OnMoveToRegion = null;
+                _map.OnMoveCamera = null;
+            }
+        }
 
         public abstract void OnMoveToRegionRequest(MoveToRegionMessage m);
         public abstract void OnMoveCameraRequest(CameraUpdateMessage m);

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/BaseCameraLogic.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms.GoogleMaps.Internals;
+
+namespace Xamarin.Forms.GoogleMaps.Logics
+{
+    internal abstract class BaseCameraLogic<TNativeMap> : IMapRequestDelegate
+    {
+        public abstract void Register(Map map, TNativeMap nativeMap);
+        public abstract void Unregister();
+
+        public abstract void OnMoveToRegionRequest(MoveToRegionMessage m);
+        public abstract void OnMoveCameraRequest(CameraUpdateMessage m);
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using Xamarin.Forms.GoogleMaps.Internals;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.GoogleMaps
 {
@@ -43,6 +44,8 @@ namespace Xamarin.Forms.GoogleMaps
         public event EventHandler<CameraChangedEventArgs> CameraChanged;
 
         internal Action<MoveToRegionMessage> OnMoveToRegion { get; set; }
+
+        internal Action<CameraUpdateMessage> OnMoveCamera { get; set; }
 
         MapSpan _visibleRegion;
 
@@ -167,6 +170,18 @@ namespace Xamarin.Forms.GoogleMaps
             SendMoveToRegion(new MoveToRegionMessage(mapSpan, animate));
         }
 
+        public Task<AnimationStatus> MoveCamera(CameraUpdate cameraUpdate)
+        {
+            var comp = new TaskCompletionSource<AnimationStatus>();
+
+
+            SendMoveCamera(new CameraUpdateMessage(cameraUpdate, new DelegateAnimationCallback(
+                () => comp.SetResult(AnimationStatus.Finished), 
+                () => comp.SetResult(AnimationStatus.Canceled))));
+
+            return comp.Task;
+        }
+
         void PinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null && e.NewItems.Cast<Pin>().Any(pin => pin.Label == null))
@@ -260,6 +275,11 @@ namespace Xamarin.Forms.GoogleMaps
         private void SendMoveToRegion(MoveToRegionMessage message)
         {
             OnMoveToRegion?.Invoke(message);
+        }
+
+        void SendMoveCamera(CameraUpdateMessage message)
+        {
+            OnMoveCamera?.Invoke(message);
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
@@ -174,7 +174,6 @@ namespace Xamarin.Forms.GoogleMaps
         {
             var comp = new TaskCompletionSource<AnimationStatus>();
 
-
             SendMoveCamera(new CameraUpdateMessage(cameraUpdate, new DelegateAnimationCallback(
                 () => comp.SetResult(AnimationStatus.Finished), 
                 () => comp.SetResult(AnimationStatus.Canceled))));

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
@@ -31,6 +31,7 @@
     <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Logics\BaseCameraLogic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Distance.cs" />
     <Compile Include="Geocoder.cs" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
@@ -66,6 +66,13 @@
     <Compile Include="CameraChangedEventArgs.cs" />
     <Compile Include="Internals\GeoConstants.cs" />
     <Compile Include="Internals\IMapRequestDelegate.cs" />
+    <Compile Include="CameraUpdateFactory.cs" />
+    <Compile Include="CameraUpdate.cs" />
+    <Compile Include="Internals\CameraUpdateMessage.cs" />
+    <Compile Include="Internals\IAnimationCallback.cs" />
+    <Compile Include="AnimationStatus.cs" />
+    <Compile Include="Internals\DelegateAnimationCallback.cs" />
+    <Compile Include="Internals\CameraUpdateType.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>


### PR DESCRIPTION
#7

Add Map.MoveCamera(CameraUpdate) method.

## USAGE

Inspired from [Google Maps Android API](https://developers.google.com/android/reference/com/google/android/gms/maps/CameraUpdateFactory).

```csharp
// Move by LatLng
Task<AnimationStatus> status = await map.MoveCamera(
    CameraUpdateFactory.NewPosition(new Position(34d, 134d)));
Debug.WriteLine($"MoveCamera finished status = {status}");

// Move by LatLng and Zoom
status = await map.MoveCamera(
    CameraUpdateFactory.NewPositionZoom(new Position(34d, 134d), 14d));
Debug.WriteLine($"MoveCamera finished status = {status}");

// Move by LatLng-Bounds
status = await map.MoveCamera(
    CameraUpdateFactory.NewBounds(
                    new Bounds(new Position(34d, 134d),  // SouthWest
                               new Position(35d, 135d)), // NorthEast
                    50)); // padding:50px
Debug.WriteLine($"MoveCamera finished status = {status}");

// Move by CameraPosition
status = await map.MoveCamera(
    CameraUpdateFactory.NewCameraPosition(
                    new CameraPosition(
                        new Position(34d, 134d),
                        45d, // bearing
                        60d, // tilt
                        17d))); // zoom
Debug.WriteLine($"MoveCamera finished status = {status}");
```
## SUPPORT PLATFORMS

* [x] Android
* [x] iOS
* [x] UWP

Also I'll create ``AnimateCamera`` to next PR.
