### PR TITLE
Fix Map.MoveCamera with bounds does not reset rotation

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/CameraLogic.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Forms.GoogleMaps.UWP.Logics
                     _nativeMap.ZoomLevel = m.Update.Zoom;
                     break;
                 case CameraUpdateType.LatLngBounds:
+                    _nativeMap.Heading = 0d;
                     await _nativeMap.TrySetViewBoundsAsync(
                         m.Update.Bounds.ToGeoboundingBox(), null, MapAnimationKind.None);
                     break;


### PR DESCRIPTION
#192 Map.MoveCamera(CameraUpdateFactory.NewBounds(…)) does not reset rotation in UWP