### PR TITLE
Fix [UWP]Map.VisibleRegion is null when first CameraChanged

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -112,9 +112,8 @@ namespace Xamarin.Forms.Maps.WinRT
                 camera.Pitch,
                 sender.ZoomLevel);
             Map.CameraPosition = pos;
-            Map?.SendCameraChanged(pos);
-
             await UpdateVisibleRegion();
+            Map?.SendCameraChanged(pos);
         }
 
         private void OnActualCameraChanged(MapControl sender, MapActualCameraChangedEventArgs args)


### PR DESCRIPTION
ref #216 