### PR TITLE
Add Padding Property Support (Android / iOS)

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -145,6 +145,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 map.MyLocationEnabled = map.UiSettings.MyLocationButtonEnabled = Map.IsShowingUser;
                 map.TrafficEnabled = Map.IsTrafficEnabled;
                 SetMapType();
+                SetPadding();
             }
 
             foreach (var logic in _logics)
@@ -216,6 +217,12 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 return;
             }
 
+            if (e.PropertyName == Map.PaddingProperty.PropertyName)
+            {
+                SetPadding();
+                return;
+            }
+
             if (NativeMap == null)
                 return;
 
@@ -260,6 +267,11 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        void SetPadding()
+        {
+            NativeMap?.SetPadding((int)Map.Padding.Left, (int)Map.Padding.Top, (int)Map.Padding.Right, (int)Map.Padding.Bottom);
         }
 
         public void OnCameraChange(GCameraPosition pos)

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/ThicknessExtension.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Extensions/ThicknessExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using UIKit;
+
+namespace Xamarin.Forms.GoogleMaps.iOS.Extensions
+{
+    internal static class ThicknessExtension
+    {
+        public static UIEdgeInsets ToUIEdgeInsets(this Thickness self)
+        {
+            return new UIEdgeInsets((nfloat)self.Top, (nfloat)self.Left, (nfloat)self.Bottom, (nfloat)self.Right);
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -113,6 +113,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                 UpdateHasScrollEnabled();
                 UpdateHasZoomEnabled();
                 UpdateIsTrafficEnabled();
+                UpdatePadding();
 
                 foreach (var logic in _logics)
                 {
@@ -161,7 +162,10 @@ namespace Xamarin.Forms.GoogleMaps.iOS
             {
                 _shouldUpdateRegion = true;
             }
-
+            else if (e.PropertyName == Map.PaddingProperty.PropertyName)
+            {
+                UpdatePadding();
+            }
 
             foreach (var logic in _logics)
             {
@@ -267,6 +271,11 @@ namespace Xamarin.Forms.GoogleMaps.iOS
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        void UpdatePadding()
+        {
+            ((MapView)Control).Padding = ((Map)Element).Padding.ToUIEdgeInsets();
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Xamarin.Forms.GoogleMaps.iOS.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Extensions\BoundsExtensions.cs" />
     <Compile Include="Extensions\PointExtensions.cs" />
     <Compile Include="Extensions\CameraPositionExtensions.cs" />
+    <Compile Include="Extensions\ThicknessExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Forms.GoogleMaps
                 ((Map)bindable)._useMoveToRegisonAsInitialBounds = false;   
             });
 
+        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(PaddingProperty), typeof(Thickness), typeof(Map), default(Thickness));
+
         bool _useMoveToRegisonAsInitialBounds = true;
 
         public static readonly BindableProperty CameraPositionProperty = BindableProperty.Create(
@@ -127,6 +129,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (CameraPosition)GetValue(CameraPositionProperty); }
             internal set { SetValue(CameraPositionProperty, value); }
+        }
+
+        public Thickness Padding
+        {
+            get { return (Thickness)GetValue(PaddingProperty); }
+            set { SetValue(PaddingProperty, value); }
         }
 
         public IList<Pin> Pins


### PR DESCRIPTION
Add wrapped padding parameter, and add process it for android and iOS.

The original parameter type is double, but it pass to native with truncate to nfloat or int.
I'm not confident that is correct :(

related issue #71