### PR TITLE
properly implement ZoomEnabled=False on UWP

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -363,7 +363,7 @@ namespace Xamarin.Forms.Maps.WinRT
         {
             Control.ZoomInteractionMode = Element.HasZoomEnabled
                 ? MapInteractionMode.GestureAndControl
-                : MapInteractionMode.ControlOnly;
+                : MapInteractionMode.Disabled;
         }
 
         void UpdateHasScrollEnabled()


### PR DESCRIPTION
Completely remove Zoom controls from UWP when ZoomEnabled = false