### PR TITLE
Polyline zIndex, polyline for UWP and UWP Pin InfoWindowClick

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             opts.InvokeWidth(outerItem.StrokeWidth * this.ScaledDensity); // TODO: convert from px to pt. Is this collect? (looks like same iOS Maps)
             opts.InvokeColor(outerItem.StrokeColor.ToAndroid());
             opts.Clickable(outerItem.IsClickable);
+            opts.InvokeZIndex(outerItem.ZIndex);
 
             var nativePolyline = NativeMap.AddPolyline(opts);
 
@@ -105,6 +106,10 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             else if (e.PropertyName == Polyline.IsClickableProperty.PropertyName)
             {
                 nativePolyline.Clickable = polyline.IsClickable;
+            }
+            else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName)
+            {
+                nativePolyline.ZIndex = polyline.ZIndex;
             }
         }
     }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls.Maps;
+using Windows.UI.Xaml.Input;
 using Xamarin.Forms.GoogleMaps.Extensions.UWP;
 using Xamarin.Forms.GoogleMaps.UWP;
 
@@ -69,6 +70,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
             var pushpin = new PushPin(outerItem);
             pushpin.Tapped += Pushpin_Tapped;
             pushpin.Holding += Pushpin_Holding;
+            pushpin.InfoWindowClicked += PushpinOnInfoWindowClicked;
 
             pushpin.Visibility = outerItem?.IsVisible ?? false ?
                 Windows.UI.Xaml.Visibility.Visible :
@@ -76,6 +78,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
 
             NativeMap.Children.Add(pushpin);
             return pushpin;
+        }
+
+        private void PushpinOnInfoWindowClicked(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+        {
+            Map.SendInfoWindowClicked(((Pin)sender));
         }
 
         private void Pushpin_Holding(object sender, Windows.UI.Xaml.Input.HoldingRoutedEventArgs e)

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Windows.Devices.Geolocation;
+using Windows.UI.Xaml.Controls.Maps;
+using Xamarin.Forms.Platform.UWP;
+
+namespace Xamarin.Forms.GoogleMaps.Logics.UWP
+{
+    internal class PolylineLogic : DefaultLogic<Polyline, MapPolyline, MapControl>
+    {
+        internal override void Register(MapControl oldNativeMap, Map oldMap, MapControl newNativeMap, Map newMap)
+        {
+            base.Register(oldNativeMap, oldMap, newNativeMap, newMap);
+
+            if (newNativeMap != null)
+            {
+                newNativeMap.MapElementClick += NewNativeMapOnMapElementClick;
+            }
+        }
+
+        private void NewNativeMapOnMapElementClick(MapControl sender, MapElementClickEventArgs args)
+        {
+            var nativeItem = args.MapElements.FirstOrDefault(e => e is MapPolyline) as MapPolyline;
+
+            if (nativeItem != null)
+            {
+                var targetOuterItem = GetItems(Map)
+                    .FirstOrDefault(outerItem => ((MapPolyline) outerItem.NativeObject) == nativeItem && outerItem.IsClickable);
+
+                targetOuterItem?.SendTap();
+            }
+        }
+
+        protected override IList<Polyline> GetItems(Map map) => map.Polylines;
+
+        protected override MapPolyline CreateNativeItem(Polyline outerItem)
+        {
+            Color color = outerItem.StrokeColor;
+            Geopath geopath = new Geopath(outerItem.Positions.Select(position => new BasicGeoposition { Latitude = position.Latitude, Longitude = position.Longitude }));
+            
+            MapPolyline polyline = new MapPolyline
+            {
+                StrokeColor = Windows.UI.Color.FromArgb(
+                    (byte)(color.A * 255),
+                    (byte)(color.R * 255),
+                    (byte)(color.G * 255),
+                    (byte)(color.B * 255)),
+                StrokeThickness = outerItem.StrokeWidth,
+                ZIndex = outerItem.ZIndex,
+                Path = geopath
+            };
+
+            NativeMap.MapElements.Add(polyline);
+
+            outerItem.NativeObject = polyline;
+
+            return polyline;
+        }
+
+        protected override MapPolyline DeleteNativeItem(Polyline outerItem)
+        {
+            var polyline = outerItem.NativeObject as MapPolyline;
+
+            if (polyline == null)
+            {
+                return null;
+            }
+
+            NativeMap.MapElements.Remove(polyline);
+
+            outerItem.NativeObject = null;
+
+            return polyline;
+        }
+
+        protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnItemPropertyChanged(sender, e);
+            var polyline = sender as Polyline;
+            var nativePolyline = polyline?.NativeObject as MapPolyline;
+
+            if (nativePolyline == null)
+                return;
+
+            if (e.PropertyName == Polyline.StrokeWidthProperty.PropertyName)
+            {
+                nativePolyline.StrokeThickness = polyline.StrokeWidth;
+            }
+            else if (e.PropertyName == Polyline.StrokeColorProperty.PropertyName)
+            {
+                var color = polyline.StrokeColor;
+
+                nativePolyline.StrokeColor = Windows.UI.Color.FromArgb(
+                    (byte)(color.A * 255),
+                    (byte)(color.R * 255),
+                    (byte)(color.G * 255),
+                    (byte)(color.B * 255));
+            }
+            else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName)
+            {
+                nativePolyline.ZIndex = polyline.ZIndex;
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
@@ -20,6 +20,16 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
             }
         }
 
+        internal override void Unregister(MapControl nativeMap, Map map)
+        {
+            base.Unregister(nativeMap, map);
+
+            if (nativeMap != null)
+            {
+                nativeMap.MapElementClick -= NewNativeMapOnMapElementClick;
+            }
+        }
+
         private void NewNativeMapOnMapElementClick(MapControl sender, MapElementClickEventArgs args)
         {
             var nativeItem = args.MapElements.FirstOrDefault(e => e is MapPolyline) as MapPolyline;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Maps.WinRT
             _logics = new BaseLogic<MapControl>[]
             {
                 new PinLogic(),
+                new PolylineLogic(),
                 new TileLayerLogic(),
             };
         }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/PushPin.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/PushPin.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Forms.Maps.WinRT
         public TextBlock Address { get; set; }
         public FrameworkElement Icon { get; set; }
 
+        public event EventHandler<TappedRoutedEventArgs> InfoWindowClicked;
+
         internal PushPin(Pin pin)
         {
             if (pin == null)
@@ -87,6 +89,7 @@ namespace Xamarin.Forms.Maps.WinRT
                 DetailsView.Height = 35;
             }
             DetailsView.Visibility = Visibility.Collapsed;
+            DetailsView.Tapped += DetailsViewOnTapped;
             Root.Children.Add(DetailsView);
         }
 
@@ -155,6 +158,11 @@ namespace Xamarin.Forms.Maps.WinRT
             {
 
             }
+        }
+
+        private void DetailsViewOnTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+        {
+            InfoWindowClicked?.Invoke(_pin, tappedRoutedEventArgs);
         }
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
             nativePolyline.StrokeWidth = outerItem.StrokeWidth;
             nativePolyline.StrokeColor = outerItem.StrokeColor.ToUIColor();
             nativePolyline.Tappable = outerItem.IsClickable;
+            nativePolyline.ZIndex = outerItem.ZIndex;
 
             outerItem.NativeObject = nativePolyline;
             nativePolyline.Map = NativeMap;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.GoogleMaps
         public static readonly BindableProperty StrokeWidthProperty = BindableProperty.Create(nameof(StrokeWidth), typeof(float), typeof(float), 1f);
         public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(Color), Color.Blue);
         public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(bool), false);
+        public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Pin), 0);
 
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 
@@ -36,6 +37,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (bool)GetValue(IsClickableProperty); }
             set { SetValue(IsClickableProperty, value); }
+        }
+
+        public int ZIndex
+        {
+            get { return (int)GetValue(ZIndexProperty); }
+            set { SetValue(ZIndexProperty, value); }
         }
 
         public IList<Position> Positions


### PR DESCRIPTION
ZIndex property for polyline, because it was hidden under the custom map tiles.
Added polyline logics for UWP platform.
Added event for InfoWindowClick for UWP