### PR TITLE
Added zIndex property for polyline

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             opts.InvokeWidth(outerItem.StrokeWidth * this.ScaledDensity); // TODO: convert from px to pt. Is this collect? (looks like same iOS Maps)
             opts.InvokeColor(outerItem.StrokeColor.ToAndroid());
             opts.Clickable(outerItem.IsClickable);
+            opts.InvokeZIndex(outerItem.ZIndex);
 
             var nativePolyline = NativeMap.AddPolyline(opts);
 
@@ -105,6 +106,10 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             else if (e.PropertyName == Polyline.IsClickableProperty.PropertyName)
             {
                 nativePolyline.Clickable = polyline.IsClickable;
+            }
+            else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName)
+            {
+                nativePolyline.ZIndex = polyline.ZIndex;
             }
         }
     }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
             nativePolyline.StrokeWidth = outerItem.StrokeWidth;
             nativePolyline.StrokeColor = outerItem.StrokeColor.ToUIColor();
             nativePolyline.Tappable = outerItem.IsClickable;
+            nativePolyline.ZIndex = outerItem.ZIndex;
 
             outerItem.NativeObject = nativePolyline;
             nativePolyline.Map = NativeMap;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.GoogleMaps
         public static readonly BindableProperty StrokeWidthProperty = BindableProperty.Create(nameof(StrokeWidth), typeof(float), typeof(float), 1f);
         public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(Color), Color.Blue);
         public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(bool), false);
+        public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Pin), 0);
 
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 
@@ -36,6 +37,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (bool)GetValue(IsClickableProperty); }
             set { SetValue(IsClickableProperty, value); }
+        }
+
+        public int ZIndex
+        {
+            get { return (int)GetValue(ZIndexProperty); }
+            set { SetValue(ZIndexProperty, value); }
         }
 
         public IList<Position> Positions


### PR DESCRIPTION
When i create map with custom tiles and then add polyline, it is hidden under the custom tiles
zIndex will help the polyline to show over the tiles

Example:
`private void CreateRoute(Polyline polyline)
        {
            polyline.StrokeWidth = 4;
            polyline.ZIndex = 1000;
            Map.Polylines.Clear();
            Map.Polylines.Add(polyline);
        }`