### PR TITLE
Polyline for UWP

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolylineLogic.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             opts.InvokeWidth(outerItem.StrokeWidth * this.ScaledDensity); // TODO: convert from px to pt. Is this collect? (looks like same iOS Maps)
             opts.InvokeColor(outerItem.StrokeColor.ToAndroid());
             opts.Clickable(outerItem.IsClickable);
+            opts.InvokeZIndex(outerItem.ZIndex);
 
             var nativePolyline = NativeMap.AddPolyline(opts);
 
@@ -105,6 +106,10 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
             else if (e.PropertyName == Polyline.IsClickableProperty.PropertyName)
             {
                 nativePolyline.Clickable = polyline.IsClickable;
+            }
+            else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName)
+            {
+                nativePolyline.ZIndex = polyline.ZIndex;
             }
         }
     }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PolylineLogic.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Windows.Devices.Geolocation;
+using Windows.UI.Xaml.Controls.Maps;
+using Xamarin.Forms.Platform.UWP;
+
+namespace Xamarin.Forms.GoogleMaps.Logics.UWP
+{
+    internal class PolylineLogic : DefaultLogic<Polyline, MapPolyline, MapControl>
+    {
+        internal override void Register(MapControl oldNativeMap, Map oldMap, MapControl newNativeMap, Map newMap)
+        {
+            base.Register(oldNativeMap, oldMap, newNativeMap, newMap);
+
+            if (newNativeMap != null)
+            {
+                newNativeMap.MapElementClick += NewNativeMapOnMapElementClick;
+            }
+        }
+
+        internal override void Unregister(MapControl nativeMap, Map map)
+        {
+            base.Unregister(nativeMap, map);
+
+            if (nativeMap != null)
+            {
+                nativeMap.MapElementClick -= NewNativeMapOnMapElementClick;
+            }
+        }
+
+        private void NewNativeMapOnMapElementClick(MapControl sender, MapElementClickEventArgs args)
+        {
+            var nativeItem = args.MapElements.FirstOrDefault(e => e is MapPolyline) as MapPolyline;
+
+            if (nativeItem != null)
+            {
+                var targetOuterItem = GetItems(Map)
+                    .FirstOrDefault(outerItem => ((MapPolyline) outerItem.NativeObject) == nativeItem && outerItem.IsClickable);
+
+                targetOuterItem?.SendTap();
+            }
+        }
+
+        protected override IList<Polyline> GetItems(Map map) => map.Polylines;
+
+        protected override MapPolyline CreateNativeItem(Polyline outerItem)
+        {
+            Color color = outerItem.StrokeColor;
+            Geopath geopath = new Geopath(outerItem.Positions.Select(position => new BasicGeoposition { Latitude = position.Latitude, Longitude = position.Longitude }));
+            
+            MapPolyline polyline = new MapPolyline
+            {
+                StrokeColor = Windows.UI.Color.FromArgb(
+                    (byte)(color.A * 255),
+                    (byte)(color.R * 255),
+                    (byte)(color.G * 255),
+                    (byte)(color.B * 255)),
+                StrokeThickness = outerItem.StrokeWidth,
+                ZIndex = outerItem.ZIndex,
+                Path = geopath
+            };
+
+            NativeMap.MapElements.Add(polyline);
+
+            outerItem.NativeObject = polyline;
+
+            return polyline;
+        }
+
+        protected override MapPolyline DeleteNativeItem(Polyline outerItem)
+        {
+            var polyline = outerItem.NativeObject as MapPolyline;
+
+            if (polyline == null)
+            {
+                return null;
+            }
+
+            NativeMap.MapElements.Remove(polyline);
+
+            outerItem.NativeObject = null;
+
+            return polyline;
+        }
+
+        protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnItemPropertyChanged(sender, e);
+            var polyline = sender as Polyline;
+            var nativePolyline = polyline?.NativeObject as MapPolyline;
+
+            if (nativePolyline == null)
+                return;
+
+            if (e.PropertyName == Polyline.StrokeWidthProperty.PropertyName)
+            {
+                nativePolyline.StrokeThickness = polyline.StrokeWidth;
+            }
+            else if (e.PropertyName == Polyline.StrokeColorProperty.PropertyName)
+            {
+                var color = polyline.StrokeColor;
+
+                nativePolyline.StrokeColor = Windows.UI.Color.FromArgb(
+                    (byte)(color.A * 255),
+                    (byte)(color.R * 255),
+                    (byte)(color.G * 255),
+                    (byte)(color.B * 255));
+            }
+            else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName)
+            {
+                nativePolyline.ZIndex = polyline.ZIndex;
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Maps.WinRT
             _logics = new BaseLogic<MapControl>[]
             {
                 new PinLogic(),
+                new PolylineLogic(),
                 new TileLayerLogic(),
             };
         }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolylineLogic.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
             nativePolyline.StrokeWidth = outerItem.StrokeWidth;
             nativePolyline.StrokeColor = outerItem.StrokeColor.ToUIColor();
             nativePolyline.Tappable = outerItem.IsClickable;
+            nativePolyline.ZIndex = outerItem.ZIndex;
 
             outerItem.NativeObject = nativePolyline;
             nativePolyline.Map = NativeMap;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.GoogleMaps
         public static readonly BindableProperty StrokeWidthProperty = BindableProperty.Create(nameof(StrokeWidth), typeof(float), typeof(float), 1f);
         public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(Color), Color.Blue);
         public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(bool), false);
+        public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Pin), 0);
 
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 
@@ -36,6 +37,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (bool)GetValue(IsClickableProperty); }
             set { SetValue(IsClickableProperty, value); }
+        }
+
+        public int ZIndex
+        {
+            get { return (int)GetValue(ZIndexProperty); }
+            set { SetValue(ZIndexProperty, value); }
         }
 
         public IList<Position> Positions


### PR DESCRIPTION
This request enables to use polylines on UWP, nothing was changed in the way of creating polylines in the Xamarin.Forms part, just PolylineLogic was created in the UWP part and added to the UWP MapRenderer.

Note: this branch was checked out from branch issue_325 which is in pull request 328, because it also contains zIndex for this polyline.