### PR TITLE
InfoWindowClick for UWP

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls.Maps;
+using Windows.UI.Xaml.Input;
 using Xamarin.Forms.GoogleMaps.Extensions.UWP;
 using Xamarin.Forms.GoogleMaps.UWP;
 
@@ -69,6 +70,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
             var pushpin = new PushPin(outerItem);
             pushpin.Tapped += Pushpin_Tapped;
             pushpin.Holding += Pushpin_Holding;
+            pushpin.InfoWindowClicked += PushpinOnInfoWindowClicked;
 
             pushpin.Visibility = outerItem?.IsVisible ?? false ?
                 Windows.UI.Xaml.Visibility.Visible :
@@ -76,6 +78,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
 
             NativeMap.Children.Add(pushpin);
             return pushpin;
+        }
+
+        private void PushpinOnInfoWindowClicked(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+        {
+            Map.SendInfoWindowClicked(((Pin)sender));
         }
 
         private void Pushpin_Holding(object sender, Windows.UI.Xaml.Input.HoldingRoutedEventArgs e)

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/PushPin.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/PushPin.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Forms.Maps.WinRT
         public TextBlock Address { get; set; }
         public FrameworkElement Icon { get; set; }
 
+        public event EventHandler<TappedRoutedEventArgs> InfoWindowClicked;
+
         internal PushPin(Pin pin)
         {
             if (pin == null)
@@ -87,6 +89,7 @@ namespace Xamarin.Forms.Maps.WinRT
                 DetailsView.Height = 35;
             }
             DetailsView.Visibility = Visibility.Collapsed;
+            DetailsView.Tapped += DetailsViewOnTapped;
             Root.Children.Add(DetailsView);
         }
 
@@ -155,6 +158,11 @@ namespace Xamarin.Forms.Maps.WinRT
             {
 
             }
+        }
+
+        private void DetailsViewOnTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+        {
+            InfoWindowClicked?.Invoke(_pin, tappedRoutedEventArgs);
         }
     }
 }


### PR DESCRIPTION
UWP Has custom info window over the pin but click event is not implemented
This commit implements click event in the same way as Android or iOS