### PR TITLE
Implemented PinChangedEvent for UWP

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
             if (Map.SelectedPin != null)
             {
                 Map.SelectedPin = null;
+                Map.SendSelectedPinChanged(null);
             }
         }
 
@@ -115,12 +116,17 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
 
             if (targetPin != null && !ReferenceEquals(targetPin, Map.SelectedPin))
             {
+                if (Map.SelectedPin != null)
+                {
+                    Map.SendSelectedPinChanged(null);
+                }
                 Map.SelectedPin = targetPin;
             }
             else
             {
                 Map.SelectedPin = null;
             }
+            Map.SendSelectedPinChanged(Map.SelectedPin);
         }
 
         Pin LookupPin(PushPin marker)


### PR DESCRIPTION
All for pinChangedEvent was already prepared but is was not implemented, in this commit, i implemented PinChangedEvent i a way it works on android plugin
When user clicks outside of any pin, PinChangedEvent with null is called and if some pin is selected and user clicks on another, first PinChangedEvent with null is called and then PinChangedEvent with new pin is called.