### PR TITLE
Implemented ZIndexes for Circle and Polygon

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CircleLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/CircleLogic.cs
@@ -92,6 +92,9 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
 
         protected override void OnUpdateIsClickable(Circle outerItem, NativeCircle nativeItem)
             => nativeItem.Clickable = outerItem.IsClickable;
+
+        protected override void OnUpdateZIndex(Circle outerItem, NativeCircle nativeItem)
+            => nativeItem.ZIndex = outerItem.ZIndex;
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolygonLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PolygonLogic.cs
@@ -123,6 +123,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
         {
             nativeItem.FillColor = outerItem.FillColor.ToAndroid();
         }
+
+        internal override void OnUpdateZIndex(Polygon outerItem, NativePolygon nativeItem)
+        {
+            nativeItem.ZIndex = outerItem.ZIndex;
+        }
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CircleLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CircleLogic.cs
@@ -78,6 +78,9 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
 
         protected override void OnUpdateIsClickable(Circle outerItem, NativeCircle nativeItem)
             => nativeItem.Tappable = outerItem.IsClickable;
+
+        protected override void OnUpdateZIndex(Circle outerItem, NativeCircle nativeItem)
+            => nativeItem.ZIndex = outerItem.ZIndex;
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolygonLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/PolygonLogic.cs
@@ -94,6 +94,11 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
         {
             nativeItem.FillColor = outerItem.FillColor.ToUIColor();
         }
+
+        internal override void OnUpdateZIndex(Polygon outerItem, NativePolygon nativeItem)
+        {
+            nativeItem.ZIndex = outerItem.ZIndex;
+        }
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Circle.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Circle.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.GoogleMaps
 
         public static readonly BindableProperty CenterProperty = BindableProperty.Create(nameof(Center), typeof(Position), typeof(Circle), default(Position));
         public static readonly BindableProperty RadiusProperty = BindableProperty.Create(nameof(Radius), typeof(Distance), typeof(Circle), Distance.FromMeters(1));
+        public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Circle), 0);
 
         public float StrokeWidth
         {
@@ -48,6 +49,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (Distance)GetValue(RadiusProperty); }
             set { SetValue(RadiusProperty, value); }
+        }
+
+        public int ZIndex
+        {
+            get { return (int)GetValue(ZIndexProperty); }
+            set { SetValue(ZIndexProperty, value); }
         }
 
         public object Tag { get; set; }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultCircleLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultCircleLogic.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.GoogleMaps.Logics
             else if (e.PropertyName == Circle.CenterProperty.PropertyName) OnUpdateCenter(outerItem, nativeItem);
             else if (e.PropertyName == Circle.RadiusProperty.PropertyName) OnUpdateRadius(outerItem, nativeItem);
             else if (e.PropertyName == Circle.IsClickableProperty.PropertyName) OnUpdateIsClickable(outerItem, nativeItem);
+            else if (e.PropertyName == Circle.ZIndexProperty.PropertyName) OnUpdateZIndex(outerItem, nativeItem);
         }
 
         protected abstract void OnUpdateStrokeWidth(Circle outerItem, TNative nativeItem);
@@ -36,6 +37,8 @@ namespace Xamarin.Forms.GoogleMaps.Logics
         protected abstract void OnUpdateRadius(Circle outerItem, TNative nativeItem);
 
         protected abstract void OnUpdateIsClickable(Circle outerItem, TNative nativeItem);
+
+        protected abstract void OnUpdateZIndex(Circle outerItem, TNative nativeItem);
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultPolygonLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Logics/DefaultPolygonLogic.cs
@@ -20,11 +20,13 @@ namespace Xamarin.Forms.GoogleMaps.Logics
             else if (e.PropertyName == Polygon.StrokeColorProperty.PropertyName) OnUpdateStrokeColor(outerItem, nativeItem);
             else if (e.PropertyName == Polygon.StrokeWidthProperty.PropertyName) OnUpdateStrokeWidth(outerItem, nativeItem);
             else if (e.PropertyName == Polygon.FillColorProperty.PropertyName) OnUpdateFillColor(outerItem, nativeItem);
+            else if (e.PropertyName == Polygon.ZIndexProperty.PropertyName) OnUpdateZIndex(outerItem, nativeItem);
         }
 
         internal abstract void OnUpdateIsClickable(Polygon outerItem, TNative nativeItem);
         internal abstract void OnUpdateStrokeColor(Polygon outerItem, TNative nativeItem);
         internal abstract void OnUpdateStrokeWidth(Polygon outerItem, TNative nativeItem);
         internal abstract void OnUpdateFillColor(Polygon outerItem, TNative nativeItem);
+        internal abstract void OnUpdateZIndex(Polygon outerItem, TNative nativeItem);
     }
 }

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polygon.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polygon.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.GoogleMaps
         public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(Polygon), Color.Blue);
         public static readonly BindableProperty FillColorProperty = BindableProperty.Create(nameof(FillColor), typeof(Color), typeof(Polygon), Color.Blue);
         public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(Polygon), false);
+        public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Polygon), 0);
 
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
         private readonly ObservableCollection<Position[]> _holes = new ObservableCollection<Position[]>();
@@ -40,6 +41,12 @@ namespace Xamarin.Forms.GoogleMaps
         {
             get { return (bool)GetValue(IsClickableProperty); }
             set { SetValue(IsClickableProperty, value); }
+        }
+
+        public int ZIndex
+        {
+            get { return (int) GetValue(ZIndexProperty); }
+            set { SetValue(ZIndexProperty, value); }
         }
 
         public IList<Position[]> Holes


### PR DESCRIPTION
ZIndexes implemented for circle and polygon, usage is simple:
var circle = new Circle {ZIndex=10};
var polygon = new Polygon {ZIndex = 5};