### PR TITLE
Fix Android ZoomControlEnabled UiSettings

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -312,7 +312,6 @@ namespace Xamarin.Forms.GoogleMaps.Android
 
         private void UpdateHasZoomEnabled()
         {
-            NativeMap.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
             NativeMap.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
         }
 


### PR DESCRIPTION
Deprecated Property HasZoomEnabled was overriding UiSettings ZoomControlEnabled property, so that overlay zoom controls on Android couldn't be deactivated.