### PR TITLE
InitialCameraUpdate string parsing bugfix

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Helpers/CameraUpdateConverter.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Helpers/CameraUpdateConverter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.GoogleMaps.Helpers
             foreach (var v in values)
             {
                 double ret;
-                if (!double.TryParse(v, out ret))
+                if (!double.TryParse(v, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out ret))
                 {
                     throw new ArgumentException(err);
                 }


### PR DESCRIPTION
Some device cultures parse doubles with commas instead of dots. This resulted in `5.2` being parsed as `52` for example.