### PR TITLE
Fixed issue #423

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -71,6 +71,11 @@ namespace Xamarin.Forms.GoogleMaps.Android
         {
             base.OnElementChanged(e);
 
+            if (e.OldElement == e.NewElement)
+            {
+                return;
+            }
+
             // For XAML Previewer or FormsGoogleMaps.Init not called.
             if (!FormsGoogleMaps.IsInitialized)
             {
@@ -112,7 +117,6 @@ namespace Xamarin.Forms.GoogleMaps.Android
 
                 oldMapModel.OnSnapshot -= OnSnapshot;
                 _cameraLogic.Unregister();
-                oldMapView.Dispose();
             }
 
             if (oldMapView != null)


### PR DESCRIPTION
Calling dispose on oldMapView causes crash later, because later await oldMapView.GetGoogleMapAsync() is called.

- I removed call to Dispose, because it shouldn't be done as oldMapView = (MapView)Control and this is the currently used control
- When you put Map inside TableView and scroll it off the screen and back it reloads map every time and causes poor performance. It's probably because of reusing cell. To fix it we need to just check if e.OldElement == e.NewElement and skip reloading