### PR TITLE
Added FromEncodedString for Polylines

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Helpers/PolylineConverter.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Helpers/PolylineConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.GoogleMaps.Helpers
+{
+    public static class PolylineConverter
+    {
+        public static List<Position> DecodePolyline(string encodedPolyline)
+        {
+            if (string.IsNullOrWhiteSpace(encodedPolyline))
+                return null;
+
+            int index = 0;
+            var polylineChars = encodedPolyline.ToCharArray();
+            var poly = new List<Position>();
+            int currentLat = 0;
+            int currentLng = 0;
+            int next5Bits;
+
+            while (index < polylineChars.Length)
+            {
+                int sum = 0;
+                int shifter = 0;
+
+                do
+                {
+                    next5Bits = polylineChars[index++] - 63;
+                    sum |= (next5Bits & 31) << shifter;
+                    shifter += 5;
+                }
+                while (next5Bits >= 32 && index < polylineChars.Length);
+
+                if (index >= polylineChars.Length)
+                    break;
+
+                currentLat += (sum & 1) == 1 ? ~(sum >> 1) : (sum >> 1);
+                sum = 0;
+                shifter = 0;
+
+                do
+                {
+                    next5Bits = polylineChars[index++] - 63;
+                    sum |= (next5Bits & 31) << shifter;
+                    shifter += 5;
+                }
+                while (next5Bits >= 32 && index < polylineChars.Length);
+
+                if (index >= polylineChars.Length && next5Bits >= 32)
+                {
+                    break;
+                }
+
+                currentLng += (sum & 1) == 1 ? ~(sum >> 1) : (sum >> 1);
+                var mLatLng = new Position(Convert.ToDouble(currentLat) / 100000.0, Convert.ToDouble(currentLng) / 100000.0);
+                poly.Add(mLatLng);
+            }
+
+            return poly;
+        }
+    }
+}

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Polyline.cs
@@ -83,6 +83,23 @@ namespace Xamarin.Forms.GoogleMaps
         {
             _positionsChangedHandler?.Invoke(this, e);
         }
+
+        public static Polyline FromEncodedString(string encodedPolyline)
+        {
+            if (String.IsNullOrEmpty(encodedPolyline))
+                return null;
+
+            var positions = Helpers.PolylineConverter.DecodePolyline(encodedPolyline);
+            if (positions != null)
+            {
+                var polyline = new Polyline();
+                foreach (var pos in positions)
+                    polyline.Positions.Add(pos);
+                return polyline;
+            }
+            else
+                return null;
+        }
     }
 }
 

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.csproj
@@ -31,6 +31,7 @@
     <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Helpers\PolylineConverter.cs" />
     <Compile Include="InfoWindowLongClickedEventArgs.cs" />
     <Compile Include="Internals\TakeSnapshotMessage.cs" />
     <Compile Include="Logics\BaseCameraLogic.cs" />
@@ -105,9 +106,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Helpers\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(SolutionDir)\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <ProjectExtensions>


### PR DESCRIPTION
As discussed in this issue / feature request:
https://github.com/amay077/Xamarin.Forms.GoogleMaps/issues/471

You can now create a Polyline from a encoded string by:

```
var polyline = Polyline.FromEncodedString("w`q~F|xbvO|a@{D");
```