### PR TITLE
Issue 487: VisibleRegion corners coordinates

### DIFF
--- a/XFGoogleMapSample/XFGoogleMapSample/App.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/App.xaml.cs
@@ -10,7 +10,7 @@ namespace XFGoogleMapSample
         {
             InitializeComponent();
 
-            MainPage = new NavigationPage(new MainPage());
+            MainPage = new NavigationPage(new local.BoundsTestPage());//MainPage());
         }
 
         protected override void OnStart()

--- a/XFGoogleMapSample/XFGoogleMapSample/BoundsTestPage.xaml
+++ b/XFGoogleMapSample/XFGoogleMapSample/BoundsTestPage.xaml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Xamarin.Forms.GoogleMaps;assembly=Xamarin.Forms.GoogleMaps"
+             x:Class="XFGoogleMapSample.local.BoundsTestPage"
+             Title="Bounds Test Page">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Search" Priority="0" />
+        <ToolbarItem Text="Sync" Priority="1" />
+    </ContentPage.ToolbarItems>
+    <!--<ContentPage.Padding>
+        <OnPlatform x:TypeArguments="Thickness">
+            <OnPlatform.Platforms>
+                <On Platform="iOS" Value="0, 20, 0, 0" />
+                <On Platform="Android" Value="0, 0, 0, 0" />
+                <On Platform="UWP" Value="0, 0, 0, 0" />
+            </OnPlatform.Platforms>
+        </OnPlatform>
+    </ContentPage.Padding>-->
+    <ContentPage.Content>
+        <AbsoluteLayout 
+            x:Name="navLayoutPage" 
+            VerticalOptions="FillAndExpand" 
+            HorizontalOptions="FillAndExpand"
+            Margin="0,0,0,0"
+            >
+            <maps:Map
+                    x:Name="mainMap"
+                    IsShowingUser="False"
+                    MapType="Satellite" 
+                    AbsoluteLayout.LayoutBounds="0,0,1,1"
+                    AbsoluteLayout.LayoutFlags="All"
+                    />
+            <!--<skiaSharp:SKCanvasView
+                x:Name="canvasView" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
+                BackgroundColor="Transparent"
+                InputTransparent="True"
+                AbsoluteLayout.LayoutBounds="0,0,1,1"
+                AbsoluteLayout.LayoutFlags="All"/> -->
+            </AbsoluteLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/XFGoogleMapSample/XFGoogleMapSample/BoundsTestPage.xaml.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/BoundsTestPage.xaml.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.GoogleMaps;
+using Xamarin.Forms.Xaml;
+
+namespace XFGoogleMapSample.local
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class BoundsTestPage : ContentPage
+	{
+		public BoundsTestPage ()
+		{
+			InitializeComponent ();
+
+            // Colosseum of Rome: 41.890251, 12.492373
+            var center = new Position(41.890251, 12.492373);
+
+            //mainMap.MoveToRegion(new MapSpan(center, 0.2, 0.2), false);
+            mainMap.UiSettings.RotateGesturesEnabled = false;
+            mainMap.UiSettings.ZoomControlsEnabled = false;
+            mainMap.UiSettings.CompassEnabled = false;
+            mainMap.CameraIdled += MainMap_CameraIdled;
+            mainMap.CameraMoveStarted += MainMap_CameraMoveStarted;
+            mainMap.MapClicked += MainMap_MapClicked;
+        }
+
+        private void MainMap_MapClicked(object sender, MapClickedEventArgs e)
+        {
+            Map _m = sender as Map;
+            Position clickPoint = e.Point;
+
+            // Now calculate the minimum value to accept point as "clicked", based on current Visible Area...
+            var currentAreaRadius = _m.VisibleRegion.Radius.Kilometers;
+            double acceptableValue = currentAreaRadius * 0.15;
+
+            Debug.WriteLine($"Map clicked at position {e.Point.Latitude} - {e.Point.Longitude}");
+        }
+
+        private void MainMap_CameraMoveStarted(object sender, CameraMoveStartedEventArgs e)
+        {
+            //throw new NotImplementedException();
+        }
+
+        private void MainMap_CameraIdled(object sender, CameraIdledEventArgs e)
+        {
+            //Map _m = sender as Map;
+            //var region = _m.VisibleRegion;
+            //var center = region.Center;
+            //var halfheightDegrees = region.LatitudeDegrees / 2;
+            //var halfwidthDegrees = region.LongitudeDegrees / 2;
+
+            //var left = center.Longitude - halfwidthDegrees;
+            //var right = center.Longitude + halfwidthDegrees;
+            //var top = center.Latitude + halfheightDegrees;
+            //var bottom = center.Latitude - halfheightDegrees;
+
+            //// Adjust for Internation Date Line (+/- 180 degrees longitude)
+            //if (left < -180) left = 180 + (180 + left);
+            //if (right > 180) right = (right - 180) - 180;
+
+            Map _map = sender as Map;
+            //Bounds bounds = Xamarin.Forms.GoogleMaps.Extensions.MapSpanExtensions.ToBounds(_map.VisibleRegion);
+            //Debug.WriteLine($"[Map bounds]\r\nNW: {bounds.NorthWest.Latitude}, {bounds.NorthWest.Longitude}\r\nNE: {bounds.NorthEast.Latitude}, {bounds.NorthEast.Longitude}\r\n" +
+            //    $"SW: {bounds.SouthWest.Latitude}, {bounds.SouthWest.Longitude}\r\nSE: {bounds.SouthEast.Latitude}, {bounds.SouthEast.Longitude}");
+
+            //Debug.WriteLine($"[_map bound]\r\nTL: {_map.TopLeft.Latitude}, {_map.TopLeft.Longitude}\r\nTR: {_map.TopRight.Latitude}, {_map.TopRight.Longitude}\r\n" +
+            //    $"BL: {_map.BottomLeft.Latitude}, {_map.BottomLeft.Longitude}\r\nBR: {_map.BottomRight.Latitude}, {_map.BottomRight.Longitude}");
+
+            if (_map.Pins.Count > 0)
+            {
+                _map.Pins.Clear();
+            }
+            _map.Pins.Add(new Pin()
+            {
+                Label = "TL",
+                Position = _map.TopLeft,
+                Rotation = 135f
+            });
+
+            _map.Pins.Add(new Pin()
+            {
+                Label = "TR",
+                Position = _map.TopRight,
+                Rotation = -135f
+            });
+
+            _map.Pins.Add(new Pin()
+            {
+                Label = "BL",
+                Position = _map.BottomLeft,
+                Rotation = 45f
+            });
+
+            _map.Pins.Add(new Pin()
+            {
+                Label = "BR",
+                Position = _map.BottomRight,
+                Rotation = -45f
+            });
+
+            // Now I should convert coordinates to map...
+            Position Rome = new Position(41.890251, 12.492373);
+            _map.Pins.Add(new Pin()
+            {
+                Label = "Rome real",
+                Position = Rome,
+                Rotation = 15f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.Blue)
+            });
+
+            double yMerTl = MercatorProjection.latToY(_map.TopLeft.Latitude);
+            double xMerTl = MercatorProjection.lonToX(_map.TopLeft.Longitude);
+
+            double yMerBr = MercatorProjection.latToY(_map.BottomRight.Latitude);
+            double xMerBr = MercatorProjection.lonToX(_map.BottomRight.Longitude);
+
+            double xRome = MercatorProjection.lonToX(Rome.Longitude);
+            double yRome = MercatorProjection.latToY(Rome.Latitude);
+
+            Position romeFromMer = new Position(MercatorProjection.yToLat(yRome), MercatorProjection.xToLon(xRome));
+            _map.Pins.Add(new Pin()
+            {
+                Label = "Rome mercator",
+                Position = romeFromMer,
+                Rotation = -15f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.DarkGreen)
+            });
+
+            double xScale = (double)_map.Width / Math.Abs(xMerBr - xMerTl);
+            double yScale = -(double)_map.Height / Math.Abs(yMerTl - yMerBr);
+
+            // get rome x and y respect to width / height...
+            double xRelativeRome = (xRome - xMerTl) * xScale;
+            double yRelativeRome = (yRome - yMerTl) * yScale;
+
+            double xInverseRome = (xRelativeRome / xScale) + xMerTl;
+            double yInverseRome = (yRelativeRome / yScale) + yMerTl;
+            Position romeInverse = new Position(MercatorProjection.yToLat(yInverseRome), MercatorProjection.xToLon(xRome));
+            _map.Pins.Add(new Pin()
+            {
+                Label = "Rome inverse",
+                Position = romeInverse,
+                Rotation = -35f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.AliceBlue)
+            });
+
+            // Now place always a point on the center of map, using scaled x-y values...
+            Point centerPoint = new Point(_map.Width / 2, _map.Height / 2);
+            double xCenter = (centerPoint.X / xScale) + xMerTl;
+            double yCenter = (centerPoint.Y / yScale) + yMerTl;
+            // TODO: check Longitude result...
+            // Adjust for Internation Date Line (+/- 180 degrees longitude)
+            var xLon = MercatorProjection.xToLon(xCenter);
+            if (xLon < -180)
+            {
+                xLon = 180 + (180 + xLon);
+            }
+            if (xLon > 180)
+            {
+                xLon = (xLon - 180) - 180;
+            }
+
+            var yLat = MercatorProjection.yToLat(yCenter);
+
+            Position centerPos = new Position(yLat, xLon);//MercatorProjection.yToLat(yCenter), MercatorProjection.xToLon(xCenter));
+            _map.Pins.Add(new Pin()
+            {
+                Label = "Center inverse",
+                Position = centerPos,
+                Rotation = -180f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.Yellow)
+            });
+
+            // Add tests limits points:
+            _map.Pins.Add(new Pin()
+            {
+                Label = "0,0",
+                Position = new Position(0d,0d),
+                Rotation = 0f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.AliceBlue)
+            });
+
+            _map.Pins.Add(new Pin()
+            {
+                Label = "0,180",
+                Position = new Position(0d, 180d),
+                Rotation = 0f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.WhiteSmoke)
+            });
+            _map.Pins.Add(new Pin()
+            {
+                Label = "0,-180",
+                Position = new Position(0d, 180d),
+                Rotation = -80f,
+                Icon = BitmapDescriptorFactory.DefaultMarker(Color.Violet)
+            });
+        }
+    }
+}

--- a/XFGoogleMapSample/XFGoogleMapSample/MercatorProjection.cs
+++ b/XFGoogleMapSample/XFGoogleMapSample/MercatorProjection.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XFGoogleMapSample.local
+{
+    public static class MercatorProjection
+    {
+        private static readonly double R_MAJOR = 6378137.0;
+        private static readonly double R_MINOR = 6356752.3142;
+        private static readonly double RATIO = R_MINOR / R_MAJOR;
+        private static readonly double ECCENT = Math.Sqrt(1.0 - (RATIO * RATIO));
+        private static readonly double COM = 0.5 * ECCENT;
+
+        private static readonly double DEG2RAD = Math.PI / 180.0;
+        private static readonly double RAD2Deg = 180.0 / Math.PI;
+        private static readonly double PI_2 = Math.PI / 2.0;
+
+        public static double[] toPixel(double lon, double lat)
+        {
+            return new double[] { lonToX(lon), latToY(lat) };
+        }
+
+        public static double[] toGeoCoord(double x, double y)
+        {
+            return new double[] { xToLon(x), yToLat(y) };
+        }
+
+        public static double lonToX(double lon)
+        {
+            return R_MAJOR * DegToRad(lon);
+        }
+
+        public static double latToY(double lat)
+        {
+            lat = Math.Min(89.5, Math.Max(lat, -89.5));
+            double phi = DegToRad(lat);
+            double sinphi = Math.Sin(phi);
+            double con = ECCENT * sinphi;
+            con = Math.Pow(((1.0 - con) / (1.0 + con)), COM);
+            double ts = Math.Tan(0.5 * ((Math.PI * 0.5) - phi)) / con;
+            return 0 - R_MAJOR * Math.Log(ts);
+        }
+
+        public static double xToLon(double x)
+        {
+            return RadToDeg(x) / R_MAJOR;
+        }
+
+        public static double yToLat(double y)
+        {
+            double ts = Math.Exp(-y / R_MAJOR);
+            double phi = PI_2 - 2 * Math.Atan(ts);
+            double dphi = 1.0;
+            int i = 0;
+            while ((Math.Abs(dphi) > 0.000000001) && (i < 15))
+            {
+                double con = ECCENT * Math.Sin(phi);
+                dphi = PI_2 - 2 * Math.Atan(ts * Math.Pow((1.0 - con) / (1.0 + con), COM)) - phi;
+                phi += dphi;
+                i++;
+            }
+            return RadToDeg(phi);
+        }
+
+        private static double RadToDeg(double rad)
+        {
+            return rad * RAD2Deg;
+        }
+
+        private static double DegToRad(double deg)
+        {
+            return deg * DEG2RAD;
+        }
+    }
+}
+

--- a/XFGoogleMapSample/XFGoogleMapSample/XFGoogleMapSample.local.csproj
+++ b/XFGoogleMapSample/XFGoogleMapSample/XFGoogleMapSample.local.csproj
@@ -32,4 +32,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Forms.GoogleMaps\Xamarin.Forms.GoogleMaps\Xamarin.Forms.GoogleMaps.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="BoundsTestPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -410,6 +410,12 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 dlat,
                 dlong
             );
+            // Simone Marra
+            ((Map)Element).TopLeft = new Position(ul.Latitude, ul.Longitude);
+            ((Map)Element).TopRight = new Position(ur.Latitude, ur.Longitude);
+            ((Map)Element).BottomLeft = new Position(ll.Latitude, ll.Longitude);
+            ((Map)Element).BottomRight = new Position(lr.Latitude, lr.Longitude);
+            // End Simone Marra
         }
 
         #region Overridable Members

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/MapRenderer.cs
@@ -249,6 +249,9 @@ namespace Xamarin.Forms.Maps.WinRT
                     var latitudeDelta = Math.Abs(center.Latitude - boundingBox.NorthwestCorner.Latitude);
                     var longitudeDelta = Math.Abs(center.Longitude - boundingBox.NorthwestCorner.Longitude);
                     Element.VisibleRegion = new MapSpan(center, latitudeDelta, longitudeDelta);
+                    // Simone Marra
+                    UpdateCornersBounds(this.Control);
+                    // End Simone Marra
                 }
             }
             catch (Exception)
@@ -256,6 +259,94 @@ namespace Xamarin.Forms.Maps.WinRT
                 //couldnt update visible region
             }
         }
+
+        // Simone Marra
+        private void UpdateCornersBounds(MapControl map)
+        {
+            Geopoint topLeft = null;
+            Geopoint topRight = null;
+            Geopoint bottomLeft = null;
+            Geopoint bottomRight = null;
+
+            // TODO: [Simone] I'm not sure about the catch code... I have not tested it yet!
+
+            try
+            {
+                map.GetLocationFromOffset(new Windows.Foundation.Point(0, 0), out topLeft);
+            }
+            catch
+            {
+                var topOfMap = new Geopoint(new BasicGeoposition()
+                {
+                    Latitude = 85,
+                    Longitude = 0
+                });
+
+                Windows.Foundation.Point topPoint;
+                map.GetOffsetFromLocation(topOfMap, out topPoint);
+                map.GetLocationFromOffset(new Windows.Foundation.Point(0, topPoint.Y), out topLeft);
+            }
+
+            try
+            {
+                map.GetLocationFromOffset(new Windows.Foundation.Point(map.ActualWidth, 0), out topRight);
+            }
+            catch
+            {
+                var topOfMap = new Geopoint(new BasicGeoposition()
+                {
+                    Latitude = 85,
+                    Longitude = 0
+                });
+
+                Windows.Foundation.Point topPoint;
+                map.GetOffsetFromLocation(topOfMap, out topPoint);
+                map.GetLocationFromOffset(new Windows.Foundation.Point(topPoint.X, topPoint.Y), out topRight);
+            }
+
+            try
+            {
+                map.GetLocationFromOffset(new Windows.Foundation.Point(map.ActualWidth, map.ActualHeight), out bottomRight);
+            }
+            catch
+            {
+                var bottomOfMap = new Geopoint(new BasicGeoposition()
+                {
+                    Latitude = -85,
+                    Longitude = 0
+                });
+
+                Windows.Foundation.Point bottomPoint;
+                map.GetOffsetFromLocation(bottomOfMap, out bottomPoint);
+                map.GetLocationFromOffset(new Windows.Foundation.Point(bottomPoint.X, bottomPoint.Y), out bottomRight);
+            }
+
+            try
+            {
+                map.GetLocationFromOffset(new Windows.Foundation.Point(0, map.ActualHeight), out bottomLeft);
+            }
+            catch
+            {
+                var bottomOfMap = new Geopoint(new BasicGeoposition()
+                {
+                    Latitude = -85,
+                    Longitude = 0
+                });
+
+                Windows.Foundation.Point bottomPoint;
+                map.GetOffsetFromLocation(bottomOfMap, out bottomPoint);
+                map.GetLocationFromOffset(new Windows.Foundation.Point(0, bottomPoint.Y), out bottomLeft);
+            }
+
+            if((topLeft != null) && (topRight != null) && (bottomLeft != null) && (bottomRight != null))
+            {
+                Element.TopLeft = new Position(topLeft.Position.Latitude, topLeft.Position.Longitude);
+                Element.TopRight = new Position(topRight.Position.Latitude, topRight.Position.Longitude);
+                Element.BottomLeft = new Position(bottomLeft.Position.Latitude, bottomLeft.Position.Longitude);
+                Element.BottomRight = new Position(bottomRight.Position.Latitude, bottomRight.Position.Longitude);
+            }
+        }
+        // End Simone Marra
 
         private static GeoboundingBox GetBounds(MapControl map)
         {

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -268,6 +268,31 @@ namespace Xamarin.Forms.GoogleMaps.iOS
             var maxLon = Math.Max(Math.Max(Math.Max(region.NearLeft.Longitude, region.NearRight.Longitude), region.FarLeft.Longitude), region.FarRight.Longitude);
             mapModel.VisibleRegion = new MapSpan(pos.Target.ToPosition(), maxLat - minLat, maxLon - minLon);
 
+            // Simone Marra
+            CoreGraphics.CGPoint topLeftPoint = new CoreGraphics.CGPoint(0, 0);
+            CoreLocation.CLLocationCoordinate2D topLeftLocation = mkMapView.Projection.CoordinateForPoint(topLeftPoint);
+
+            CoreGraphics.CGPoint bottomRightPoint = new CoreGraphics.CGPoint(mkMapView.Frame.Size.Width, mkMapView.Frame.Size.Height);
+            CoreLocation.CLLocationCoordinate2D bottomRightLocation = mkMapView.Projection.CoordinateForPoint(bottomRightPoint);
+
+            CoreGraphics.CGPoint topRightPoint = new CoreGraphics.CGPoint(mkMapView.Frame.Size.Width, 0);
+            CoreLocation.CLLocationCoordinate2D topRightLocation = mkMapView.Projection.CoordinateForPoint(topRightPoint);
+
+            CoreGraphics.CGPoint bottomLeftPoint = new CoreGraphics.CGPoint(0, mkMapView.Frame.Size.Height);
+            CoreLocation.CLLocationCoordinate2D bottomLeftLocation = mkMapView.Projection.CoordinateForPoint(bottomLeftPoint);
+
+            VisibleRegion realVisibleRegion = new VisibleRegion();
+            realVisibleRegion.FarLeft = topLeftLocation;
+            realVisibleRegion.FarRight = topRightLocation;
+            realVisibleRegion.NearLeft = bottomLeftLocation;
+            realVisibleRegion.NearRight = bottomRightLocation;
+
+            ((Map)Element).TopLeft = new Position(topLeftLocation.Latitude, topLeftLocation.Longitude);
+            ((Map)Element).TopRight = new Position(topRightLocation.Latitude, topRightLocation.Longitude);
+            ((Map)Element).BottomLeft = new Position(bottomLeftLocation.Latitude, bottomLeftLocation.Longitude);
+            ((Map)Element).BottomRight = new Position(bottomRightLocation.Latitude, bottomRightLocation.Longitude);
+            // End Simone Marra
+
             var camera = pos.ToXamarinForms();
             Map.CameraPosition = camera;
             Map.SendCameraChanged(camera);

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps/Map.cs
@@ -89,6 +89,13 @@ namespace Xamarin.Forms.GoogleMaps
 
         MapSpan _visibleRegion;
 
+        // Simone Marra
+        public static Position _TopLeft = new Position();
+        public static Position _TopRight = new Position();
+        public static Position _BottomLeft = new Position();
+        public static Position _BottomRight = new Position();
+        // End Simone Marra
+
         public Map()
         {
             VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
@@ -228,6 +235,29 @@ namespace Xamarin.Forms.GoogleMaps
                 OnPropertyChanged();
             }
         }
+
+        // Simone Marra
+        public Position TopLeft
+        {
+            get { return _TopLeft; }
+            internal set { _TopLeft = value; }
+        }
+        public Position TopRight
+        {
+            get { return _TopRight; }
+            internal set { _TopRight = value; }
+        }
+        public Position BottomLeft
+        {
+            get { return _BottomLeft; }
+            internal set { _BottomLeft = value; }
+        }
+        public Position BottomRight
+        {
+            get { return _BottomRight; }
+            internal set { _BottomRight = value; }
+        }
+        // End Simone Marra
 
         public UiSettings UiSettings { get; } = new UiSettings();
 


### PR DESCRIPTION
@amay077 **Following is a brief description of the patch.**

The patch fixes a problem related to Map Visible Region Bounds when zoom is far.
Using the added corners Latitude/Logitude we can have access of the real Latitude and Longitude of Map VisibleRegion area. I attached a basic Test Page to see differences on values retrieved using the old properties (center and bounds), respect to new TopLeft, TopRight, BottomLeft and BottomRight values.

My best solution probably should be to expose the native methods used to have projection conversion on Xamarin.Forms multiplatform code, but it is a bit too complex for me to add such mod. 
Using the projection conversion we could add some overlay layers on top of Map View (on a project of mine I'm using SkiaSharp canvas...), so we can draw graphics on top of Map without the need of handling custom views, icons, etc...

If you guide me to the proper way to give access to the projection Latitude/Longitude to/from Screen points methods, I will be happy to improve the patch.
I would like to be able to have the different projection conversion classes usable by multiplatform code:
- Android: **Android.Gms.Maps.Projection** (methods _FromScreenLocation_ and _ToScreenLocation_)
- iOs: **Google.Maps.Projection** (methods _CoordinateForPoint_ and _PointForCoordinate_)
- UWP: **Windows.UI.Xaml.Controls.Maps.MapControl** (methods _GetLocationFromOffset_ and _GetOffsetFromLocation_)
