### PR TITLE
Fix issue #517 (MapStyle crash on iOS)

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/MapRenderer.cs
@@ -377,8 +377,7 @@ namespace Xamarin.Forms.GoogleMaps.iOS
             }
             else
             {
-                var err = new NSError();
-                var mapStyle = Google.Maps.MapStyle.FromJson(Map.MapStyle.JsonStyle, err);
+                var mapStyle = Google.Maps.MapStyle.FromJson(Map.MapStyle.JsonStyle, null);
                 ((MapView)Control).MapStyle = mapStyle;
             }
         }


### PR DESCRIPTION
Fixes Issue #517 

This change will fix the bug that was introduced with commit  https://github.com/amay077/Xamarin.Forms.GoogleMaps/commit/c116222e388631b61712905e42895cffa8798234

The commit referenced above changed the behaviour when calling the method `Google.Maps.MapStyle.FromJson(Map.MapStyle.JsonStyle, err);` inside the `UpdateMapStyle()` method of the iOS `MapRenderer`.

This new behaviour causes the map to raise a native crash on iOS 10.0+, when the application is compiled with the `Deployment Target` set to 10.0+.

This pull request restores the original behaviour of sending `null` as the second parameter to the `Google.Maps.MapStyle.FromJson` method to avoid the crash.

