### PR TITLE
Invalid CoordinateBounds was created when Longitude<-90 or Longitude>90

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.iOS/Logics/CameraLogic.cs
@@ -48,8 +48,15 @@ namespace Xamarin.Forms.GoogleMaps.Logics.iOS
             Position center = mapSpan.Center;
             var halfLat = mapSpan.LatitudeDegrees / 2d;
             var halfLong = mapSpan.LongitudeDegrees / 2d;
-            var mapRegion = new CoordinateBounds(new CLLocationCoordinate2D(center.Latitude - halfLat, center.Longitude - halfLong),
-                new CLLocationCoordinate2D(center.Latitude + halfLat, center.Longitude + halfLong));
+            var mapRegion = new CoordinateBounds(new VisibleRegion(
+                center.Latitude + halfLat,
+                center.Longitude + halfLong + (center.Longitude + halfLong > 180 ? -360 : 0),
+                center.Latitude + halfLat,
+                center.Longitude - halfLong + (center.Longitude - halfLong < -180 ? 360 : 0),
+                center.Latitude - halfLat,
+                center.Longitude + halfLong + (center.Longitude + halfLong > 180 ? -360 : 0),
+                center.Latitude - halfLat,
+                center.Longitude - halfLong + (center.Longitude - halfLong < -180 ? 360 : 0)));
 
             if (animated)
             {


### PR DESCRIPTION
Using another constructor for CoordinateBounds results in a valid object when the longitude of the center is <-90 or >90. With this valid object, the correct region is set.

In the original code calling MoveToRegion(MapSpan.FromCenterAndRadius(new Position(0, 91), Distance.FromKilometers(10000)), false);
or
MoveToRegion(MapSpan.FromCenterAndRadius(new Position(0, -91), Distance.FromKilometers(10000)), false);
did not set the region. With the new code it correctly sets the region.