### PR TITLE
Make Android MapRenderer.NativeMap overridable

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
         protected internal static PlatformConfig Config { protected get; set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
-        protected virtual GoogleMap NativeMap { get; set; }
+        protected virtual GoogleMap NativeMap { get; private set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
         protected Map Map => Element;

--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
         protected internal static PlatformConfig Config { protected get; set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
-        protected GoogleMap NativeMap { get; private set; }
+        protected virtual GoogleMap NativeMap { get; set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
         protected Map Map => Element;


### PR DESCRIPTION
This is useful when someone wants to combine this library with a closed source library that
provides its own GoogleMap instance.

I'm currently happily using this library, but have to combine it with a third party library that provides a SupportMapFragment subclass. I've got it working by overriding the MapRenderer.OnElementChanged() method and doing a lot of reflection as a substitute for calling the base method. By making the property virtual it allows a hook to provide a substitute GoogleMap instance.