### PR TITLE
Check that marker is on map before setting the icon

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Logics/PinLogic.cs
@@ -326,9 +326,14 @@ namespace Xamarin.Forms.GoogleMaps.Logics.Android
                 var otherView = new FrameLayout(nativeView.Context);
                 nativeView.LayoutParameters = new FrameLayout.LayoutParams(Utils.DpToPx((float)iconView.WidthRequest), Utils.DpToPx((float)iconView.HeightRequest));
                 otherView.AddView(nativeView);
-                nativeItem.SetIcon(await Utils.ConvertViewToBitmapDescriptor(otherView));
-                nativeItem.SetAnchor((float)iconView.AnchorX, (float)iconView.AnchorY);
-                nativeItem.Visible = true;
+
+                var icon = await Utils.ConvertViewToBitmapDescriptor(otherView);
+                if (outerItem.NativeObject != null)
+                {
+                    nativeItem.SetIcon(icon);
+                    nativeItem.SetAnchor((float)iconView.AnchorX, (float)iconView.AnchorY);
+                    nativeItem.Visible = true;
+                }
             }
         }
 


### PR DESCRIPTION
There is a race condition in the case the following situation happens:

1. User updates the icon of a Pin with a BitmapDescriptorFactory.FromView()
2. Immediately after remove the Pin from the map

This results in this library calling SetIcon() on the native marker AFTER it has been removed from the native map. This results in Google Maps throwing a `Java.Lang.IllegalArgumentException: Unmanaged descriptor` exception.

By checking that the marker hasn't been removed before calling SetIcon() we can prevent this exception.