### PR TITLE
Upgrade GooglePlayServices version

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/packages.config
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Annotations" version="26.0.2" targetFramework="monoandroid80" />
@@ -18,8 +18,8 @@
   <package id="Xamarin.Android.Support.Vector.Drawable" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Build.Download" version="0.4.11" targetFramework="monoandroid80" />
   <package id="Xamarin.Forms" version="3.0.0.482510" targetFramework="monoandroid60" />
-  <package id="Xamarin.GooglePlayServices.Base" version="60.1142.1" targetFramework="monoandroid80" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="60.1142.1" targetFramework="monoandroid80" />
-  <package id="Xamarin.GooglePlayServices.Maps" version="60.1142.1" targetFramework="monoandroid80" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="60.1142.1" targetFramework="monoandroid80" />
+  <package id="Xamarin.GooglePlayServices.Base" version="71.1610.0" targetFramework="monoandroid80" />
+  <package id="Xamarin.GooglePlayServices.Basement" version="71.1610.0" targetFramework="monoandroid80" />
+  <package id="Xamarin.GooglePlayServices.Maps" version="71.1610.0" targetFramework="monoandroid80" />
+  <package id="Xamarin.GooglePlayServices.Tasks" version="71.1610.0" targetFramework="monoandroid80" />
 </packages>


### PR DESCRIPTION
Old GooglePlayServices in incompatible with all new plugins.

Also remove unnecessary whitespace character before opening xml tag.

@amay077 Contribution guideline mentions "Run all the tests to assure nothing else was accidentally broken", but I did not see any tests that could be run.  I am therefore unsure if this update breaks anything.  Please advise.