### PR TITLE
Pin icons should be loaded from resources instead of assets #709 fixed

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Factories/DefaultBitmapDescriptorFactory.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/Factories/DefaultBitmapDescriptorFactory.cs
@@ -26,8 +26,10 @@ namespace Xamarin.Forms.GoogleMaps.Android.Factories
                 case BitmapDescriptorType.Default:
                     return AndroidBitmapDescriptorFactory.DefaultMarker((float)((descriptor.Color.Hue * 360f) % 360f));
                 case BitmapDescriptorType.Bundle:
-                    return AndroidBitmapDescriptorFactory.FromAsset(descriptor.BundleName);
-                case BitmapDescriptorType.Stream:
+					var context = FormsGoogleMaps.Context;
+					var resourceId = context.Resources.GetIdentifier(descriptor.BundleName, "drawable", context.PackageName);
+					return AndroidBitmapDescriptorFactory.FromResource(resourceId);
+				case BitmapDescriptorType.Stream:
                     if (descriptor.Stream.CanSeek && descriptor.Stream.Position > 0)
                     {
                         descriptor.Stream.Position = 0;


### PR DESCRIPTION
In the following PR i replaced instead of using assets to use from drawables