### PR TITLE
Issue #746: Disable default info window when tapping on a pin in UWP

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.UWP/Logics/PinLogic.cs
@@ -120,8 +120,17 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
 
         private void Pushpin_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            //Select pin
             var pin = (sender as PushPin);
+            var targetPin = LookupPin(pin);
+            
+            // If set to PinClickedEventArgs.Handled = true in app codes,
+            // then all pin selection controlling by app.
+            if (Map.SendPinClicked(targetPin))
+            {
+                return;
+            }
+            
+            //Select pin
             if (Map.SelectedPin != null)
             {
                 foreach (var outerItem in GetItems(Map))
@@ -133,13 +142,6 @@ namespace Xamarin.Forms.GoogleMaps.Logics.UWP
                 }
             }
             pin.DetailsView.Visibility = pin.DetailsView.Visibility == Windows.UI.Xaml.Visibility.Visible ? Windows.UI.Xaml.Visibility.Collapsed : Windows.UI.Xaml.Visibility.Visible;
-            var targetPin = LookupPin(pin);
-            // If set to PinClickedEventArgs.Handled = true in app codes,
-            // then all pin selection controlling by app.
-            if (Map.SendPinClicked(targetPin))
-            {
-                return;
-            }
 
             if (targetPin != null && !ReferenceEquals(targetPin, Map.SelectedPin))
             {


### PR DESCRIPTION
#746  
If the client code sets `PinClickedEventArgs.Handled` to `true`, then the `Pushpin_Tapped` method should not execute any of its logic (currently, it toggles the visibility of the `DetailsView` unconditionally)
